### PR TITLE
feat(dx): add subpath exports for all modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,38 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./result": {
+      "types": "./dist/result.d.ts",
+      "import": "./dist/result.js"
+    },
+    "./option": {
+      "types": "./dist/option.d.ts",
+      "import": "./dist/option.js"
+    },
+    "./async": {
+      "types": "./dist/async.d.ts",
+      "import": "./dist/async.js"
+    },
+    "./array": {
+      "types": "./dist/array.d.ts",
+      "import": "./dist/array.js"
+    },
+    "./object": {
+      "types": "./dist/object.d.ts",
+      "import": "./dist/object.js"
+    },
+    "./string": {
+      "types": "./dist/string.d.ts",
+      "import": "./dist/string.js"
+    },
+    "./predicates": {
+      "types": "./dist/predicates.d.ts",
+      "import": "./dist/predicates.js"
+    },
+    "./composition": {
+      "types": "./dist/composition.d.ts",
+      "import": "./dist/composition.js"
     }
   },
   "files": ["dist", "README.md", "LICENSE"],


### PR DESCRIPTION
Closes #5

## Context

## Motivação

Atualmente todos os imports passam pelo barrel \`fp-core\`. Bundlers modernos fazem tree-shaking, mas IDEs e ferramentas de análise estática se beneficiam de subpath exports explícitos. Alguns ambientes (Deno, edge runtimes) também preferem imports diretos.

## Proposta

Adicionar subpath exports no \`package.json\`:

\`\`\`json
{
  "exports": {
    ".": {
      "types": "./dist/index.d.ts",
      "import": "./dist/index.js"
    },
    "./result": {
      "types": "./dist/result.d.ts",
      "import": "./dist/result.js"
    },
    "./option": {
      "types": "./dist/option.d.ts",
      "import": "./dist/option.js"
    },
    "./async": {
      "types": "./dist/async.d.ts",
      "import": "./dist/async.js"
    },
    "./array": {
      "types": "./dist/array.d.ts",
      "import": "./dist/array.js"
    },
    "./object": {
      "types": "./dist/object.d.ts",
      "import": "./dist/object.js"
    },
    "./string": {
      "types": "./dist/string.d.ts",
      "import": "./dist/string.js"
    },
    "./predicates": {
      "types": "./dist/predicates.d.ts",
      "import": "./dist/predicates.js"
    }
  }
}
\`\`\`

Uso resultante:

\`\`\`typescript
import { Ok, Err, flatMap } from 'fp-core/result';
import { Some, None } from 'fp-core/option';
import { retry, timeout } from 'fp-core/async';
\`\`\`

## Critério de aceitação

- Todos os subpaths resolvem corretamente em TypeScript
- Import principal \`fp-core\` continua funcionando
- Nenhuma mudança breaking