### PR TITLE
ci: enforce coverage thresholds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Type-check
         run: npm run type-check
 
-      - name: Test
-        run: npm test
+      - name: Test with coverage
+        run: npm run test:coverage
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
Closes #6

## Context

## Contexto

O CI atual roda \`vitest\` mas não impõe nenhum threshold de cobertura — é possível adicionar código sem testes e o pipeline passa.

## Proposta

Configurar thresholds no \`vitest.config.ts\`:

\`\`\`typescript
// vitest.config.ts
export default defineConfig({
  test: {
    coverage: {
      provider: 'v8',
      thresholds: {
        lines: 90,
        functions: 90,
        branches: 85,
        statements: 90,
      },
      include: ['src/**'],
      exclude: ['src/index.ts'], // barrel sem lógica
    },
  },
});
\`\`\`

E adicionar o step no CI:

\`\`\`yaml
- name: Test with coverage
  run: npm run test:coverage
\`\`\`

> **Nota:** os thresholds só fazem sentido depois que as issues #3 e #4 (testes faltando) forem resolvidas — do contrário o pipeline falhará imediatamente.

## Critério de aceitação

- \`npm run test:coverage\` falha se cobertura cair abaixo do threshold
- CI falha em PRs que removem cobertura