### PR TITLE
docs: add CHANGELOG, migration guide, subpath imports and versioning policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,107 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Added
+- Subpath exports for granular imports (`fp-core/result`, `fp-core/option`, etc.)
+- Full test suite for `array`, `object`, `string`, and `predicates` modules
+- Coverage tests for `mapResultAsync`, `flatMapAsync`, `debounceAsync`, `throttleAsync`, `composeAsync`
+- Coverage thresholds enforced in CI (90% lines/functions/statements, 85% branches)
+
+### Fixed
+- `composeAsync` no longer mutates the caller's function array (was calling `.reverse()` in-place)
+- `unique`, `flatten`, `flattenDeep` removed unnecessary thunk layer (were `unique()([...])`, now `unique([...])`)
+
+---
+
+## [0.1.0] - 2026-03-03
+
+### Added
+
+**Core modules**
+
+- `Result<T, E>` — type-safe error handling without exceptions
+  - `Ok`, `Err`, `mapResult`, `mapError`, `flatMap`, `match`, `tryCatch`, `fromPromise`, `fromNullableResult`, `andThen`, `orElse`, `unwrapOr`, `isOk`, `isErr`, `toOption`, `validateAll`, `validateAny`, `tapResult`, `tapError`, `mapResultAsync`, `flatMapAsync`, `tryCatchAsync`, `fromPromiseResult`
+- `Option<T>` — explicit nullability without null/undefined
+  - `Some`, `None`, `fromNullable`, `mapOption`, `flatMapOption`, `matchOption`, `unwrapOptionOr`, `filterOption`, `optionToResult`, `resultToOption`, `tapOption`, `isSome`, `isNone`, `toNullable`
+
+**Composition**
+
+- `pipe(value, ...fns)` — left-to-right composition, fully typed up to 10 steps
+- `compose(...fns)` — right-to-left composition
+- `curry` — converts a multi-argument function to curried form
+- `memoize` — caches function results by argument
+- `tap` — executes a side effect and passes the value through
+- `identity` — returns its argument unchanged
+- `constant` — returns a function that always returns the same value
+- `flow` — point-free left-to-right composition
+
+**Async**
+
+- `pipeAsync` — async left-to-right composition
+- `composeAsync` — async right-to-left composition
+- `mapAsync` — sequential async map
+- `mapParallel` — parallel async map
+- `mapConcurrent` — parallel async map with concurrency limit
+- `filterAsync` — sequential async filter
+- `reduceAsync` — sequential async reduce
+- `retry` — retries with exponential backoff, returns `Result`
+- `timeout` — races a promise against a deadline
+- `sleep` — promise-based delay
+- `debounceAsync` — debounced async function
+- `throttleAsync` — throttled async function
+- `memoizeAsync` — memoized async function returning `Result`
+- `sequence` — runs async thunks sequentially
+- `parallel` — runs async thunks in parallel
+
+**Array**
+
+- `map`, `filter`, `reduce`, `flatMapArray`, `sortBy`
+- `unique`, `take`, `skip`, `find`, `some`, `every`
+- `groupBy`, `countBy`, `partition`
+- `flatten`, `flattenDeep`, `zip`, `unzip`, `chunk`, `compact`, `hasItems`
+
+**Object**
+
+- `pick`, `omit`, `merge`, `deepMerge`, `mapValues`, `filterValues`
+- `fromEntries`, `toEntries`, `groupByKey`, `invertObject`
+- `setPath`, `getPath`, `deletePath`
+- `hasKey`, `hasProperty`, `isPlainObject`
+- `keys`, `values`, `entries`
+
+**String**
+
+- `camelCase`, `pascalCase`, `kebabCase`, `snakeCase`
+- `capitalize`, `trim`, `trimStart`, `trimEnd`
+- `startsWith`, `endsWith`, `includes` (curried)
+- `truncate`, `padStart`, `padEnd`
+- `split`, `join`, `replace`, `replaceAll` (curried)
+- `template` — simple `{{variable}}` string interpolation
+- `words`, `isEmpty`, `isBlank`, `toUpperCase`, `toLowerCase`
+
+**Predicates**
+
+- `and`, `or`, `not` — predicate combinators
+- `isString`, `isNumber`, `isBoolean`, `isNull`, `isUndefined`, `isNullish`, `isDefined`
+- `isArray`, `isObject`, `isFunction`, `isDate`, `isError`, `isPromise`
+- `between`, `greaterThan`, `lessThan`, `greaterThanOrEqual`, `lessThanOrEqual`, `equals`
+- `hasProperty` — type-guarded property check
+- `hasLength`, `isEmpty` (for arrays/strings/objects)
+- `validateAll`, `validateAny` — run multiple predicates and collect results
+
+**Infrastructure**
+
+- TypeScript 5.x, `"moduleResolution": "bundler"`, strict mode
+- Vitest test suite with v8 coverage
+- GitHub Actions CI (type-check → test → build, Node 20 + 22)
+- Automated npm publish on tag push
+
+[Unreleased]: https://github.com/roxdavirox/fp-core/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/roxdavirox/fp-core/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -326,6 +326,125 @@ import { pipeAsync, retry } from 'fp-core';
 
 ---
 
+## Subpath Imports
+
+Import only the module you need for better IDE support and explicit dependency tracking:
+
+```typescript
+import { Ok, Err, flatMap, mapResult } from 'fp-core/result';
+import { Some, None, fromNullable } from 'fp-core/option';
+import { pipe, compose, curry } from 'fp-core/composition';
+import { pipeAsync, retry, timeout } from 'fp-core/async';
+import { map, filter, groupBy } from 'fp-core/array';
+import { pick, omit, setPath } from 'fp-core/object';
+import { camelCase, truncate, template } from 'fp-core/string';
+import { and, or, not, isString } from 'fp-core/predicates';
+```
+
+The root import `'fp-core'` continues to export everything and remains the default for most use cases.
+
+---
+
+## Migration Guide
+
+### Coming from Ramda
+
+| Ramda | fp-core |
+|-------|---------|
+| `R.pipe(f, g)(x)` | `pipe(x, f, g)` |
+| `R.compose(g, f)(x)` | `compose(g, f)(x)` |
+| `R.map(fn, list)` | `map(fn)(list)` |
+| `R.filter(pred, list)` | `filter(pred)(list)` |
+| `R.reduce(fn, init, list)` | `reduce(fn, init)(list)` |
+| `R.groupBy(fn, list)` | `groupBy(fn)(list)` |
+| `R.sortBy(fn, list)` | `sortBy(fn)(list)` |
+| `R.pick(['a','b'], obj)` | `pick(['a','b'])(obj)` |
+| `R.omit(['a'], obj)` | `omit(['a'])(obj)` |
+| `R.mergeRight(a, b)` | `merge(a)(b)` |
+| `R.either(f, g)` | `or(f, g)` — predicates module |
+| `R.both(f, g)` | `and(f, g)` — predicates module |
+| `R.complement(f)` | `not(f)` |
+| `R.memoize(f)` | `memoize(f)` |
+| `R.tap(fn)(x)` | `tap(fn)(x)` |
+| `R.curry(f)` | `curry(f)` |
+| `R.identity` | `identity` |
+| `R.always(x)` | `constant(x)` |
+
+Key differences:
+- **Value-first pipe**: `pipe(value, f, g)` instead of `pipe(f, g)(value)`. TypeScript infers every step without losing types.
+- **No `Maybe`/`Either`**: fp-core uses `Option<T>` and `Result<T, E>` with explicit constructors.
+- **No lens/transducer**: fp-core is intentionally limited to everyday utilities.
+
+### Coming from fp-ts
+
+| fp-ts | fp-core |
+|-------|---------|
+| `pipe(x, TE.map(f))` | `pipe(x, mapResult(f))` |
+| `E.right(x)` / `E.left(e)` | `Ok(x)` / `Err(e)` |
+| `E.map(f)(either)` | `mapResult(f)(result)` |
+| `E.chain(f)(either)` | `flatMap(f)(result)` |
+| `E.fold(onLeft, onRight)` | `match(onRight, onLeft)` |
+| `O.some(x)` / `O.none` | `Some(x)` / `None` |
+| `O.map(f)(option)` | `mapOption(f)(option)` |
+| `O.chain(f)(option)` | `flatMapOption(f)(option)` |
+| `O.fold(onNone, onSome)` | `matchOption(onSome, onNone)` |
+| `O.fromNullable(x)` | `fromNullable(x)` |
+| `TE.tryCatch(f, toError)` | `tryCatchAsync(f)` |
+| `T.sequenceArray(tasks)` | `sequence(tasks)` |
+| `A.map(f)(arr)` | `map(f)(arr)` |
+| `A.filter(pred)(arr)` | `filter(pred)(arr)` |
+| `flow(f, g)` | `flow(f, g)` or `pipe(x, f, g)` |
+
+Key differences:
+- **No HKT encoding**: fp-core does not use higher-kinded type emulation. The API is simpler but less polymorphic.
+- **No type class hierarchy**: there is no `Functor`, `Monad`, or `Applicative` abstraction — each type has its own named functions.
+- **`match` argument order**: fp-core uses `match(onOk, onErr)` (success first), while fp-ts uses `fold(onLeft, onRight)` (failure first).
+
+### Coming from lodash/fp
+
+| lodash/fp | fp-core |
+|-----------|---------|
+| `_.map(fn)(arr)` | `map(fn)(arr)` |
+| `_.filter(pred)(arr)` | `filter(pred)(arr)` |
+| `_.reduce(fn)(init)(arr)` | `reduce(fn, init)(arr)` |
+| `_.groupBy(fn)(arr)` | `groupBy(fn)(arr)` |
+| `_.sortBy(fn)(arr)` | `sortBy(fn)(arr)` |
+| `_.chunk(n)(arr)` | `chunk(n)(arr)` |
+| `_.flatten(arr)` | `flatten(arr)` |
+| `_.flattenDeep(arr)` | `flattenDeep(arr)` |
+| `_.uniq(arr)` | `unique(arr)` |
+| `_.pick(keys)(obj)` | `pick(keys)(obj)` |
+| `_.omit(keys)(obj)` | `omit(keys)(obj)` |
+| `_.merge(a)(b)` | `deepMerge(a)(b)` |
+| `_.camelCase(s)` | `camelCase(s)` |
+| `_.kebabCase(s)` | `kebabCase(s)` |
+| `_.truncate({length: n})(s)` | `truncate(n)(s)` |
+| `_.flow(f, g)` | `flow(f, g)` |
+| `_.memoize(f)` | `memoize(f)` |
+| `_.identity` | `identity` |
+| `_.constant(x)` | `constant(x)` |
+
+Key differences:
+- **TypeScript-native**: every function is typed precisely; no `any` leakage from lodash's overloads.
+- **No `_` namespace or chaining**: compose pipelines with `pipe` instead.
+- **Result/Option built-in**: fp-core replaces try/catch and null-check patterns structurally.
+
+---
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+| Change type | Version bump |
+|-------------|-------------|
+| Bugfix, doc update, internal refactor | Patch (`0.x.Y`) |
+| New exported function, new subpath, new option | Minor (`0.X.0`) |
+| Renamed/removed export, changed function signature, changed behavior | Major (`X.0.0`) |
+
+Until `1.0.0`, minor releases may include breaking changes if they are clearly documented in the [CHANGELOG](./CHANGELOG.md).
+
+---
+
 ## TypeScript Requirements
 
 - TypeScript ≥ 5.0


### PR DESCRIPTION
Closes #7

## Context

## Contexto

O README atual cobre instalação e quick start, mas não tem:

- **Migration guide** — para quem vem do Ramda, fp-ts ou lodash/fp
- **CHANGELOG** — não existe `CHANGELOG.md` no projeto
- **Versioning policy** — não está claro o critério de semver (ex: quando um breaking change vai para major)

## Escopo

### 1. `CHANGELOG.md`
Criar seguindo o padrão [Keep a Changelog](https://keepachangelog.com/):
\`\`\`
## [Unreleased]
## [0.1.0] - 2026-XX-XX
### Added
- Result<T, E>, Option<T>, pipe, compose...
\`\`\`

### 2. Seção "Migration from X" no README
\`\`\`markdown
## Coming from Ramda?
| Ramda | fp-core |
|-------|---------|
| R.pipe(f, g)(x) | pipe(x, f, g) |
| R.map(fn, list) | map(fn)(list) |
| R.either(f, g) | or(f, g) — predicates |

## Coming from fp-ts?
...
\`\`\`

### 3. Política de versionamento
Adicionar nota sobre breaking changes e semver ao README.