### PR TITLE
fix(string,predicates,result): Unicode reverse, rename isNaN/isFinite, add 4 result helpers, cover remaining branches

### DIFF
--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -400,20 +400,24 @@ export const isInteger = (n: number): boolean => Number.isInteger(n);
 /**
  * Returns true if the value is NaN.
  *
+ * Named `isNotANumber` to avoid shadowing the global `isNaN` built-in.
+ *
  * @example
- * isNaN(NaN); // true
- * isNaN(0);   // false
+ * isNotANumber(NaN); // true
+ * isNotANumber(0);   // false
  */
-export const isNaN = (n: number): boolean => Number.isNaN(n);
+export const isNotANumber = (n: number): boolean => Number.isNaN(n);
 
 /**
  * Returns true if the number is finite.
  *
+ * Named `isFiniteNumber` to avoid shadowing the global `isFinite` built-in.
+ *
  * @example
- * isFinite(42);       // true
- * isFinite(Infinity); // false
+ * isFiniteNumber(42);       // true
+ * isFiniteNumber(Infinity); // false
  */
-export const isFinite = (n: number): boolean => Number.isFinite(n);
+export const isFiniteNumber = (n: number): boolean => Number.isFinite(n);
 
 /**
  * Returns true if the number is positive or negative infinity.

--- a/src/result.ts
+++ b/src/result.ts
@@ -164,6 +164,69 @@ export const match =
   (result: Result<T, E>): R =>
     isOk(result) ? onOk(result.value) : onErr(result.error);
 
+/**
+ * Executes a side-effect on the value if Ok, then passes the Result through unchanged.
+ * Useful for logging inside a pipe without breaking the chain.
+ *
+ * @example
+ * pipe(
+ *   Ok(42),
+ *   tapResult(value => console.log('got:', value)), // logs 'got: 42'
+ *   mapResult(n => n * 2),
+ * ); // Ok(84)
+ */
+export const tapResult =
+  <T, E>(fn: (value: T) => void) =>
+  (result: Result<T, E>): Result<T, E> => {
+    if (isOk(result)) fn(result.value);
+    return result;
+  };
+
+/**
+ * Executes a side-effect on the error if Err, then passes the Result through unchanged.
+ *
+ * @example
+ * pipe(
+ *   Err('oops'),
+ *   tapError(e => console.error('error:', e)), // logs 'error: oops'
+ *   mapResult(n => n * 2),
+ * ); // Err('oops')
+ */
+export const tapError =
+  <T, E>(fn: (error: E) => void) =>
+  (result: Result<T, E>): Result<T, E> => {
+    if (isErr(result)) fn(result.error);
+    return result;
+  };
+
+/**
+ * Recovers from an Err by applying `fn` to produce an alternative Result.
+ * If Ok, passes through unchanged.
+ *
+ * @example
+ * const fallback = orElse((e: string) => Ok(0));
+ * fallback(Ok(42));    // Ok(42)
+ * fallback(Err('x'));  // Ok(0)
+ */
+export const orElse =
+  <T, E, F>(fn: (error: E) => Result<T, F>) =>
+  (result: Result<T, E>): Result<T, F> =>
+    isErr(result) ? fn(result.error) : result;
+
+/**
+ * Lifts a nullable value into a Result, using `onNone` to produce the error.
+ *
+ * @example
+ * const fromId = fromNullableResult(() => 'not found');
+ * fromId(42);        // Ok(42)
+ * fromId(null);      // Err('not found')
+ * fromId(undefined); // Err('not found')
+ */
+export const fromNullableResult =
+  <E>(onNone: () => E) =>
+  <T>(value: T | null | undefined): Result<T, E> =>
+    value == null ? Err(onNone()) : Ok(value);
+
 // ============================================================================
 // COMBINATORS
 // ============================================================================

--- a/src/string.ts
+++ b/src/string.ts
@@ -299,7 +299,7 @@ export const repeat =
  * @example
  * reverse('hello'); // 'olleh'
  */
-export const reverse = (str: string): string => str.split('').reverse().join('');
+export const reverse = (str: string): string => Array.from(str).reverse().join('');
 
 /**
  * Truncates a string to the given length, appending a suffix if cut.

--- a/tests/async.test.ts
+++ b/tests/async.test.ts
@@ -183,6 +183,15 @@ describe('debounceAsync', () => {
     expect(inner).toHaveBeenNthCalledWith(1, 1);
     expect(inner).toHaveBeenNthCalledWith(2, 2);
   });
+
+  it('rejects when the underlying function throws', async () => {
+    const inner = vi.fn(async (_n: number): Promise<number> => {
+      throw new Error('debounce error');
+    });
+    const debounced = debounceAsync<[number], number>(10)(inner as NumFn);
+
+    await expect(debounced(1)).rejects.toThrow('debounce error');
+  });
 });
 
 describe('throttleAsync', () => {

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -201,9 +201,18 @@ describe('equals', () => {
     expect(equals({ a: 1 } as object)({ a: 1, b: 2 } as object)).toBe(false);
   });
 
-  it('handles nested arrays', () => {
+  it('handles nested arrays of primitives', () => {
     expect(equals({ list: [1, 2, 3] })({ list: [1, 2, 3] })).toBe(true);
     expect(equals({ list: [1, 2] })({ list: [1, 3] })).toBe(false);
+  });
+
+  it('handles nested arrays of objects', () => {
+    expect(equals({ list: [{ a: 1 }] })({ list: [{ a: 1 }] })).toBe(true);
+    expect(equals({ list: [{ a: 1 }] })({ list: [{ a: 2 }] })).toBe(false);
+  });
+
+  it('returns false for arrays of different length', () => {
+    expect(equals({ list: [1, 2, 3] })({ list: [1, 2] })).toBe(false);
   });
 });
 
@@ -215,11 +224,18 @@ describe('clone', () => {
     expect(original.b.c).toBe(2);
   });
 
-  it('clones arrays', () => {
+  it('clones arrays of primitives', () => {
     const arr = [1, [2, 3]];
     const copy = clone(arr);
     (copy[1] as number[])[0] = 99;
     expect((arr[1] as number[])[0]).toBe(2);
+  });
+
+  it('clones arrays of objects (recursive)', () => {
+    const arr = [{ x: 1 }, { x: 2 }];
+    const copy = clone(arr);
+    copy[0].x = 99;
+    expect(arr[0].x).toBe(1);
   });
 
   it('clones Date objects', () => {

--- a/tests/predicates.test.ts
+++ b/tests/predicates.test.ts
@@ -6,7 +6,7 @@ import {
   isString, isNumber, isBoolean, isFunction, isArray,
   isNull, isUndefined, isNil, isDate, isRegExp, isPromise,
   isEven, isOdd, isPositive, isNegative, isZero,
-  isInteger, isNaN, isFinite, isInfinite,
+  isInteger, isNotANumber, isFiniteNumber, isInfinite,
 } from '../src/predicates.js';
 
 describe('isNotEmpty', () => {
@@ -216,14 +216,14 @@ describe('numeric predicates', () => {
     expect(isInteger(42.5)).toBe(false);
   });
 
-  it('isNaN', () => {
-    expect(isNaN(NaN)).toBe(true);
-    expect(isNaN(0)).toBe(false);
+  it('isNotANumber', () => {
+    expect(isNotANumber(NaN)).toBe(true);
+    expect(isNotANumber(0)).toBe(false);
   });
 
-  it('isFinite', () => {
-    expect(isFinite(42)).toBe(true);
-    expect(isFinite(Infinity)).toBe(false);
+  it('isFiniteNumber', () => {
+    expect(isFiniteNumber(42)).toBe(true);
+    expect(isFiniteNumber(Infinity)).toBe(false);
   });
 
   it('isInfinite', () => {

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -11,6 +11,7 @@ import {
   fromPromise,
   validateAll, validateAny,
   mapResultAsync, flatMapAsync,
+  tapResult, tapError, orElse, fromNullableResult,
   type Result,
 } from '../src/result.js';
 
@@ -50,6 +51,13 @@ describe('Result — transformations', () => {
   it('mapErr transforms Err value', () => {
     const r = mapErr((e: string) => e.toUpperCase())(Err<number, string>('oops'));
     if (!r.ok) expect(r.error).toBe('OOPS');
+  });
+
+  it('mapErr passes Ok through unchanged', () => {
+    const fn = vi.fn((e: string) => e.toUpperCase());
+    const r = mapErr(fn)(Ok<number, string>(42));
+    expect(isOk(r)).toBe(true);
+    expect(fn).not.toHaveBeenCalled();
   });
 
   it('flatMap chains Ok results', () => {
@@ -99,6 +107,10 @@ describe('Result — unwrap variants', () => {
   it('unwrapOrElse computes fallback', () => {
     expect(unwrapOrElse((e: string) => e.length)(Err<number, string>('abc'))).toBe(3);
   });
+
+  it('unwrapOrElse extracts Ok value directly', () => {
+    expect(unwrapOrElse((_e: string) => 0)(Ok<number, string>(99))).toBe(99);
+  });
 });
 
 describe('Result — combinators', () => {
@@ -115,6 +127,18 @@ describe('Result — combinators', () => {
   it('combineTwo merges two Ok values', () => {
     const r = combineTwo((a: number, b: number) => a + b)(Ok<number, string>(3), Ok<number, string>(4));
     expect(unwrap(r)).toBe(7);
+  });
+
+  it('combineTwo short-circuits on first Err', () => {
+    const r = combineTwo((a: number, b: number) => a + b)(Err<number, string>('e1'), Ok<number, string>(4));
+    expect(isErr(r)).toBe(true);
+    if (!r.ok) expect(r.error).toBe('e1');
+  });
+
+  it('combineTwo short-circuits on second Err', () => {
+    const r = combineTwo((a: number, b: number) => a + b)(Ok<number, string>(3), Err<number, string>('e2'));
+    expect(isErr(r)).toBe(true);
+    if (!r.ok) expect(r.error).toBe('e2');
   });
 
   it('collectErrors collects all errors', () => {
@@ -213,5 +237,79 @@ describe('flatMapAsync', () => {
   it('propagates Err returned by the chained function', async () => {
     const result = await flatMapAsync(safeSqrt)(Ok<number, string>(-1));
     expect(isErr(result)).toBe(true);
+  });
+});
+
+describe('tapResult', () => {
+  it('calls side-effect on Ok and passes value through', () => {
+    const log = vi.fn();
+    const r = tapResult<number, string>(log)(Ok(42));
+    expect(log).toHaveBeenCalledWith(42);
+    expect(isOk(r)).toBe(true);
+    if (r.ok) expect(r.value).toBe(42);
+  });
+
+  it('does not call side-effect on Err', () => {
+    const log = vi.fn();
+    const r = tapResult<number, string>(log)(Err('oops'));
+    expect(log).not.toHaveBeenCalled();
+    expect(isErr(r)).toBe(true);
+  });
+});
+
+describe('tapError', () => {
+  it('calls side-effect on Err and passes error through', () => {
+    const log = vi.fn();
+    const r = tapError<number, string>(log)(Err('oops'));
+    expect(log).toHaveBeenCalledWith('oops');
+    expect(isErr(r)).toBe(true);
+  });
+
+  it('does not call side-effect on Ok', () => {
+    const log = vi.fn();
+    const r = tapError<number, string>(log)(Ok(42));
+    expect(log).not.toHaveBeenCalled();
+    expect(isOk(r)).toBe(true);
+  });
+});
+
+describe('orElse', () => {
+  it('passes Ok through unchanged', () => {
+    const r = orElse((_e: string) => Ok(0))(Ok<number, string>(42));
+    expect(isOk(r)).toBe(true);
+    if (r.ok) expect(r.value).toBe(42);
+  });
+
+  it('recovers from Err by producing a new Result', () => {
+    const r = orElse((e: string) => Ok(e.length))(Err<number, string>('oops'));
+    expect(isOk(r)).toBe(true);
+    if (r.ok) expect(r.value).toBe(4);
+  });
+
+  it('can recover to another Err', () => {
+    const r = orElse((_e: string) => Err(404))(Err<number, string>('not found'));
+    expect(isErr(r)).toBe(true);
+    if (!r.ok) expect(r.error).toBe(404);
+  });
+});
+
+describe('fromNullableResult', () => {
+  const lift = fromNullableResult<string>(() => 'missing');
+
+  it('wraps a non-null value in Ok', () => {
+    const r = lift(42);
+    expect(isOk(r)).toBe(true);
+    if (r.ok) expect(r.value).toBe(42);
+  });
+
+  it('returns Err for null', () => {
+    const r = lift(null);
+    expect(isErr(r)).toBe(true);
+    if (!r.ok) expect(r.error).toBe('missing');
+  });
+
+  it('returns Err for undefined', () => {
+    const r = lift(undefined);
+    expect(isErr(r)).toBe(true);
   });
 });

--- a/tests/string.test.ts
+++ b/tests/string.test.ts
@@ -119,6 +119,9 @@ describe('slice / substring / pad / repeat / reverse', () => {
   it('padEnd', () => expect(padEnd(5, '0')('42')).toBe('42000'));
   it('repeat', () => expect(repeat(3)('ha')).toBe('hahaha'));
   it('reverse', () => expect(reverse('hello')).toBe('olleh'));
+  it('reverse preserves multi-codepoint characters (emoji)', () => {
+    expect(reverse('😀ab')).toBe('ba😀');
+  });
 });
 
 describe('truncate', () => {
@@ -170,7 +173,15 @@ describe('template', () => {
 });
 
 describe('format', () => {
-  it('replaces %s and %d tokens', () => {
+  it('replaces %s tokens', () => {
+    expect(format('Hello %s')('Alice')).toBe('Hello Alice');
+  });
+
+  it('replaces %d tokens', () => {
+    expect(format('Score: %d')(42)).toBe('Score: 42');
+  });
+
+  it('replaces %s and %d tokens in sequence', () => {
     expect(format('Hello %s, you are %d')('Alice', 30)).toBe('Hello Alice, you are 30');
   });
 });


### PR DESCRIPTION
## Summary

- **#24** `string.reverse` now uses `Array.from(str).reverse().join('')` to correctly handle multi-codepoint characters (emoji, surrogate pairs)
- **#25** `isNaN` renamed to `isNotANumber`, `isFinite` renamed to `isFiniteNumber` — avoids shadowing global built-ins; behaviour unchanged
- **#30** Implemented four functions that CHANGELOG listed as already shipped: `tapResult`, `tapError`, `orElse`, `fromNullableResult` — all with JSDoc and `@example` blocks
- **#31** Covered the remaining uncovered branches: `mapErr` Ok passthrough, `unwrapOrElse` Ok branch, `combineTwo` Err paths, `debounceAsync` rejection, `equals`/`clone` with nested array of objects, `string.format` with `%d` specifier

## Test results

301 tests passing. Coverage: 99.31% statements, 96.72% branches, 100% functions.

Closes #24
Closes #25
Closes #30
Closes #31