### PR TITLE
ci: project board automation, auto-labeler, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - task
+    commit-message:
+      prefix: chore(deps)
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - task
+    commit-message:
+      prefix: chore(ci)

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,51 @@
+# Used by actions/labeler to auto-label PRs by changed files
+
+result:
+  - src/result.ts
+  - src/_internal/result*.ts
+  - tests/result.test.ts
+
+option:
+  - src/option.ts
+  - tests/option.test.ts
+
+array:
+  - src/array.ts
+  - src/_internal/array*.ts
+  - tests/array.test.ts
+
+object:
+  - src/object.ts
+  - src/_internal/object*.ts
+  - tests/object.test.ts
+
+string:
+  - src/string.ts
+  - src/_internal/string*.ts
+  - tests/string.test.ts
+
+async:
+  - src/async.ts
+  - src/_internal/async*.ts
+  - tests/async.test.ts
+
+composition:
+  - src/composition.ts
+  - src/_internal/pipe.ts
+  - src/_internal/compose.ts
+  - src/_internal/fn-utils.ts
+  - tests/composition.test.ts
+
+predicates:
+  - src/predicates.ts
+  - tests/predicates.test.ts
+
+documentation:
+  - "**/*.md"
+  - docs/**
+
+ci:
+  - .github/**
+  - tsconfig*.json
+  - package*.json
+  - vitest.config*

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,20 @@
+name: Auto Label
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    name: Label PR by changed files
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/pr-sync.yml
+++ b/.github/workflows/pr-sync.yml
@@ -2,7 +2,14 @@ name: PR Sync
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, closed]
+
+# Project board IDs (mago-office, project #2)
+env:
+  PROJECT_ID: PVT_kwHOAPDgbs4BQglq
+  STATUS_FIELD: PVTSSF_lAHOAPDgbs4BQglqzg-m2Sc
+  STATUS_IN_REVIEW: c999db95
+  STATUS_DONE: c841d7a3
 
 jobs:
   sync:
@@ -20,6 +27,8 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const body = pr.body || '';
+            const isMerged = pr.merged === true;
+            const isClosed = context.payload.action === 'closed';
 
             // Extract linked issue number from "Closes #N" / "Fixes #N" / "Resolves #N"
             const match = body.match(/(?:closes|fixes|resolves)\s+#(\d+)/i);
@@ -68,9 +77,8 @@ jobs:
               }
             }
 
-            // Add PR to mago-office project board via GraphQL
+            // Project board automation
             // Requires GH_PROJECT_TOKEN secret with project:write scope.
-            // If the secret is absent, this step is skipped gracefully.
             const projectToken = process.env.GH_PROJECT_TOKEN;
             if (!projectToken) {
               console.log('GH_PROJECT_TOKEN not configured — skipping project board sync');
@@ -79,21 +87,82 @@ jobs:
 
             const { graphql } = require('@octokit/graphql');
             const gql = graphql.defaults({ headers: { authorization: `token ${projectToken}` } });
-            const prNodeId = pr.node_id;
-            try {
-              await gql(`
-                mutation($projectId: ID!, $contentId: ID!) {
-                  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
-                    item { id }
+
+            const PROJECT_ID = process.env.PROJECT_ID;
+            const STATUS_FIELD = process.env.STATUS_FIELD;
+
+            // Helper: find existing project item for a content node ID
+            async function findProjectItem(contentNodeId) {
+              try {
+                const res = await gql(`
+                  query($projectId: ID!, $cursor: String) {
+                    node(id: $projectId) {
+                      ... on ProjectV2 {
+                        items(first: 100, after: $cursor) {
+                          nodes { id content { ... on Issue { id } ... on PullRequest { id } } }
+                        }
+                      }
+                    }
                   }
+                `, { projectId: PROJECT_ID });
+                const items = res.node.items.nodes;
+                return items.find(i => i.content?.id === contentNodeId)?.id ?? null;
+              } catch {
+                return null;
+              }
+            }
+
+            // Helper: move a project item to a given status
+            async function setStatus(itemId, statusOptionId) {
+              await gql(`
+                mutation($proj: ID!, $item: ID!, $field: ID!, $val: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $proj, itemId: $item,
+                    fieldId: $field, value: { singleSelectOptionId: $val }
+                  }) { projectV2Item { id } }
                 }
-              `, {
-                projectId: 'PVT_kwHOAPDgbs4BQglq',
-                contentId: prNodeId,
-              });
-              console.log('PR added to mago-office project board');
+              `, { proj: PROJECT_ID, item: itemId, field: STATUS_FIELD, val: statusOptionId });
+            }
+
+            try {
+              // 1. Add PR to project board (idempotent)
+              const prNodeId = pr.node_id;
+              let prItemId = await findProjectItem(prNodeId);
+              if (!prItemId) {
+                const added = await gql(`
+                  mutation($projectId: ID!, $contentId: ID!) {
+                    addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                      item { id }
+                    }
+                  }
+                `, { projectId: PROJECT_ID, contentId: prNodeId });
+                prItemId = added.addProjectV2ItemById.item.id;
+                console.log('PR added to mago-office project board');
+              }
+
+              // 2. Move linked ISSUE on the board based on PR lifecycle
+              const issueNodeId = issue.node_id;
+              const issueItemId = await findProjectItem(issueNodeId);
+
+              if (issueItemId) {
+                if (isClosed && isMerged) {
+                  // PR merged → issue Done
+                  await setStatus(issueItemId, process.env.STATUS_DONE);
+                  console.log(`Issue #${issueNumber} moved to Done`);
+                } else if (!isClosed) {
+                  // PR opened/reopened → issue InReview
+                  await setStatus(issueItemId, process.env.STATUS_IN_REVIEW);
+                  console.log(`Issue #${issueNumber} moved to InReview`);
+                }
+              } else {
+                console.log(`Issue #${issueNumber} not found on project board — skipping status move`);
+              }
             } catch (err) {
-              console.log(`Could not add to project board: ${err.message}`);
+              console.log(`Project board sync error: ${err.message}`);
             }
         env:
           GH_PROJECT_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+          PROJECT_ID: ${{ env.PROJECT_ID }}
+          STATUS_FIELD: ${{ env.STATUS_FIELD }}
+          STATUS_IN_REVIEW: ${{ env.STATUS_IN_REVIEW }}
+          STATUS_DONE: ${{ env.STATUS_DONE }}


### PR DESCRIPTION
## Summary

- **pr-sync.yml** upgraded: now triggers on `closed` event — moves the linked issue to **InReview** when a PR is opened and to **Done** when merged
- **auto-label.yml** + **labeler.yml**: PRs are auto-labelled by changed files (`result`, `array`, `object`, `string`, `async`, `composition`, `predicates`, `documentation`, `ci`)
- **dependabot.yml**: weekly npm dependency updates + monthly GitHub Actions updates, auto-labelled as `task`

## Test plan

- [ ] Open a PR linked to an issue → issue card moves to InReview
- [ ] Merge the PR → issue card moves to Done
- [ ] Open a PR touching `src/array.ts` → `array` label applied automatically
- [ ] Dependabot PRs appear labelled on Monday