### PR TITLE
fix(ci): auto-merge on CI pass, block dependabot major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
+    versioning-strategy: increase-if-necessary
+    ignore:
+      # Only allow patch and minor; block major bumps
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels:
       - task
     commit-message:
@@ -15,6 +20,11 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    open-pull-requests-limit: 3
+    ignore:
+      # Block major bumps for actions too
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels:
       - task
     commit-message:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,21 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  auto-merge-dependabot:
+    name: Enable auto-merge for Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/scripts/pr-create.sh
+++ b/scripts/pr-create.sh
@@ -79,10 +79,16 @@ if [[ -n "$MILESTONE" ]]; then
   ARGS+=(--milestone "$MILESTONE")
 fi
 
-gh pr create "${ARGS[@]}"
+PR_URL=$(gh pr create "${ARGS[@]}")
+echo "$PR_URL"
+
+# Enable auto-merge: PR will merge automatically once all CI checks pass
+echo ""
+echo "==> Enabling auto-merge (squash)..."
+gh pr merge --auto --squash "$PR_URL" && echo "  Auto-merge enabled" || echo "  Could not enable auto-merge (non-fatal)"
 
 # Add PR to mago-office project board via GraphQL
-PR_NODE_ID=$(gh pr view --json nodeId -q .nodeId 2>/dev/null || echo "")
+PR_NODE_ID=$(gh pr view --json nodeId -q .nodeId "$PR_URL" 2>/dev/null || echo "")
 if [[ -n "$PR_NODE_ID" ]]; then
   echo ""
   echo "==> Adding PR to mago-office project board..."


### PR DESCRIPTION
## Problem

PRs were accumulating with no review gate and no auto-merge trigger:
- Dependabot was suggesting non-existent major versions (`actions/checkout@6`, `vitest@4`)
- Feature PRs sat green with no merge trigger

## Changes

**dependabot.yml** — ignore major version bumps
```yaml
ignore:
  - dependency-name: "*"
    update-types: ["version-update:semver-major"]
```
Only patch/minor updates will now be proposed.

**auto-merge.yml** (new) — Dependabot PRs enable `--auto` immediately on open. GitHub merges them once CI passes. No manual step.

**scripts/pr-create.sh** — every PR created via the script now enables auto-merge. Flow becomes:
```
implement → pr-create.sh → CI runs → auto-merge → done
```
No more piled-up green PRs waiting for a human click.

## Test plan
- [ ] CI green
- [ ] Dependabot PR (when next one arrives) merges itself after CI
- [ ] Feature PR created via script merges itself after CI