### PR TITLE
fix(dx): restore review loop — pr-check.sh drives review/fix/merge

### DIFF
--- a/scripts/pr-check.sh
+++ b/scripts/pr-check.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
-# Inspect CI status and review comments for a PR.
+# Review loop for a feature PR:
+#   1. Wait for CI to pass
+#   2. Print full diff + context for review
+#   3. After review fixes → commit + push
+#   4. Merge
+#
 # Usage: ./scripts/pr-check.sh [pr-number]
+#
+# This script only handles orchestration.
+# The review itself is done by Claude (run this, then invoke the review skill).
 
 set -e
 
@@ -13,40 +21,91 @@ fi
 
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
-echo "=== PR #$PR ==="
+echo "================================================================"
+echo "  PR #$PR — Review Loop"
+echo "================================================================"
 echo ""
 
-echo "--- Status ---"
+# ── 1. PR metadata ────────────────────────────────────────────────
+echo "── PR Info ──"
 gh api "repos/$REPO/pulls/$PR" \
-  --jq '"Title:     \(.title)\nState:     \(.state)\nMergeable: \(.mergeable_state)\nBranch:    \(.head.ref) -> \(.base.ref)"'
+  --jq '"  Title:  \(.title)\n  Branch: \(.head.ref) → \(.base.ref)\n  State:  \(.state)\n  URL:    \(.html_url)"'
 echo ""
 
-echo "--- CI Checks ---"
+# ── 2. Wait for CI ────────────────────────────────────────────────
+echo "── CI Status ──"
 SHA=$(gh api "repos/$REPO/pulls/$PR" --jq .head.sha)
-gh api "repos/$REPO/commits/$SHA/check-runs" \
-  --jq '.check_runs[] | "\(.conclusion // .status) \(.name)"' 2>/dev/null || echo "No checks found"
-echo ""
 
-echo "--- Reviews ---"
-gh api "repos/$REPO/pulls/$PR/reviews" \
-  --jq '.[] | "[\(.user.login)] \(.state)"' 2>/dev/null || echo "No reviews"
-echo ""
+MAX_WAIT=300   # 5 minutes
+WAITED=0
+INTERVAL=15
 
-echo "--- Inline Comments ---"
-COUNT=$(gh api "repos/$REPO/pulls/$PR/comments" --jq 'length')
-if [[ "$COUNT" -gt 0 ]]; then
-  gh api "repos/$REPO/pulls/$PR/comments" \
-    --jq '.[] | "[\(.user.login)] \(.path):\(.line // .original_line)\n\(.body)\n"'
-else
-  echo "None"
+while true; do
+  CHECKS=$(gh api "repos/$REPO/commits/$SHA/check-runs" \
+    --jq '[.check_runs[] | {name: .name, status: .status, conclusion: .conclusion}]')
+
+  PENDING=$(echo "$CHECKS" | python3 -c "
+import sys, json
+runs = json.load(sys.stdin)
+print(sum(1 for r in runs if r['status'] != 'completed'))
+")
+
+  if [[ "$PENDING" -eq 0 ]]; then
+    break
+  fi
+
+  if [[ "$WAITED" -ge "$MAX_WAIT" ]]; then
+    echo "  TIMEOUT: CI still running after ${MAX_WAIT}s"
+    exit 1
+  fi
+
+  echo "  Waiting for CI ($PENDING checks pending)..."
+  sleep "$INTERVAL"
+  WAITED=$((WAITED + INTERVAL))
+done
+
+FAILED=$(gh api "repos/$REPO/commits/$SHA/check-runs" \
+  --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped")] | length')
+
+echo "$CHECKS" | python3 -c "
+import sys, json
+runs = json.load(sys.stdin)
+for r in runs:
+    icon = '✓' if r['conclusion'] in ('success','skipped') else '✗'
+    print(f'  {icon} {r[\"name\"]} — {r[\"conclusion\"] or r[\"status\"]}')
+"
+
+if [[ "$FAILED" -gt 0 ]]; then
+  echo ""
+  echo "  FAIL: $FAILED check(s) did not pass. Fix before review."
+  exit 1
 fi
 echo ""
 
-echo "--- General Comments ---"
-GCOUNT=$(gh api "repos/$REPO/issues/$PR/comments" --jq 'length')
-if [[ "$GCOUNT" -gt 0 ]]; then
-  gh api "repos/$REPO/issues/$PR/comments" \
-    --jq '.[] | "[\(.user.login)]\n\(.body | split("\n")[0:5] | join("\n"))\n---"'
-else
-  echo "None"
-fi
+# ── 3. Full diff ──────────────────────────────────────────────────
+echo "── Diff (vs main) ──"
+gh pr diff "$PR"
+echo ""
+
+# ── 4. Test coverage delta ────────────────────────────────────────
+echo "── Files changed ──"
+gh pr view "$PR" --json files --jq '.files[] | "  \(.additions)+  \(.deletions)-  \(.path)"'
+echo ""
+
+# ── 5. Review instructions ────────────────────────────────────────
+echo "================================================================"
+echo "  REVIEW STEP"
+echo "================================================================"
+echo ""
+echo "  Claude: run the review skill on the diff above."
+echo "  Classify each finding as:"
+echo ""
+echo "    CRITICAL  — must fix before merge (correctness, type safety, breaking API)"
+echo "    MINOR     — open as GitHub issue, merge after"
+echo "    STYLE     — open as GitHub issue, merge after"
+echo ""
+echo "  After fixes are pushed to the branch:"
+echo ""
+echo "    gh pr merge $PR --squash --delete-branch"
+echo ""
+echo "================================================================"

--- a/scripts/pr-create.sh
+++ b/scripts/pr-create.sh
@@ -82,10 +82,10 @@ fi
 PR_URL=$(gh pr create "${ARGS[@]}")
 echo "$PR_URL"
 
-# Enable auto-merge: PR will merge automatically once all CI checks pass
-echo ""
-echo "==> Enabling auto-merge (squash)..."
-gh pr merge --auto --squash "$PR_URL" && echo "  Auto-merge enabled" || echo "  Could not enable auto-merge (non-fatal)"
+# Feature PRs do NOT auto-merge — they go through review first.
+# After CI passes, run: ./scripts/pr-check.sh
+# which waits for CI, runs review, fixes criticals, opens issues for the rest,
+# and only then merges.
 
 # Add PR to mago-office project board via GraphQL
 PR_NODE_ID=$(gh pr view --json nodeId -q .nodeId "$PR_URL" 2>/dev/null || echo "")


### PR DESCRIPTION
## Problem

The auto-merge I added was bypassing the review loop entirely — PRs merged the moment CI went green with no review, no criticals fixed, no issues created for minor findings.

## Changes

**pr-create.sh** — auto-merge removed from feature PRs. Comment explains why and points to pr-check.sh.

**pr-check.sh** — rewritten from read-only status checker into a full review loop driver:
1. Polls CI until all checks complete (fails if any red)
2. Prints the full diff + files changed
3. Prints review instructions with CRITICAL/MINOR/STYLE classification guide

## Loop that stays intact

```
implement feature
  → pr-create.sh          # open PR, no auto-merge
  → CI runs
  → pr-check.sh           # wait for green, print diff
  → review skill          # Claude reviews, classifies findings
  → fix CRITICAL issues   # push to same branch
  → create GitHub issues for MINOR/STYLE
  → gh pr merge --squash  # explicit merge after review is clean
  → pick next issue
```

**Dependabot PRs** still auto-merge (auto-merge.yml scoped to `dependabot[bot]`).