### PR TITLE
feat(result): add ap, liftA2, liftA3 — applicative combinators

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -273,6 +273,61 @@ export const combineAll = <T, E>(results: Array<Result<T, E>>): Result<T[], E> =
 };
 
 /**
+ * Apply a wrapped function to a wrapped value (applicative `<*>`).
+ * If either argument is `Err`, the first `Err` is returned.
+ *
+ * @example
+ * const double = (n: number) => n * 2;
+ * ap(Ok(double))(Ok(5));    // Ok(10)
+ * ap(Err('no fn'))(Ok(5));  // Err('no fn')
+ * ap(Ok(double))(Err('e')); // Err('e')
+ *
+ * // Combine independent results using curried functions:
+ * const add = (a: number) => (b: number) => a + b;
+ * ap(mapResult(add)(Ok(3)))(Ok(4)); // Ok(7)
+ */
+export const ap =
+  <T, U, E>(resultFn: Result<(a: T) => U, E>) =>
+  (result: Result<T, E>): Result<U, E> => {
+    if (isErr(resultFn)) return resultFn;
+    if (isErr(result)) return result;
+    return Ok(resultFn.value(result.value));
+  };
+
+/**
+ * Lift a 2-argument function to operate on two `Result` values.
+ * Returns `Ok(fn(a, b))` if both are `Ok`, otherwise returns the first `Err`.
+ *
+ * Alias for {@link combineTwo}.
+ *
+ * @example
+ * const add = (a: number, b: number) => a + b;
+ * liftA2(add)(Ok(3), Ok(4));    // Ok(7)
+ * liftA2(add)(Err('x'), Ok(4)); // Err('x')
+ * liftA2(add)(Ok(3), Err('y')); // Err('y')
+ */
+export const liftA2 = combineTwo;
+
+/**
+ * Lift a 3-argument function to operate on three `Result` values.
+ * Returns `Ok(fn(a, b, c))` if all are `Ok`, otherwise returns the first `Err`.
+ *
+ * @example
+ * const sum3 = (a: number, b: number, c: number) => a + b + c;
+ * liftA3(sum3)(Ok(1), Ok(2), Ok(3));    // Ok(6)
+ * liftA3(sum3)(Err('x'), Ok(2), Ok(3)); // Err('x')
+ * liftA3(sum3)(Ok(1), Err('y'), Ok(3)); // Err('y')
+ */
+export const liftA3 =
+  <A, B, C, D, E>(fn: (a: A, b: B, c: C) => D) =>
+  (ra: Result<A, E>, rb: Result<B, E>, rc: Result<C, E>): Result<D, E> => {
+    if (isErr(ra)) return ra;
+    if (isErr(rb)) return rb;
+    if (isErr(rc)) return rc;
+    return Ok(fn(ra.value, rb.value, rc.value));
+  };
+
+/**
  * Collects all errors from an array of Results
  *
  * @example

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -13,6 +13,7 @@ import {
   mapResultAsync, flatMapAsync,
   tapResult, tapError, orElse, fromNullableResult,
   bimap, mapLeft, swap, toOption,
+  ap, liftA2, liftA3,
   type Result,
 } from '../src/result.js';
 import { Some, None } from '../src/option.js';
@@ -334,4 +335,90 @@ describe('swap', () => {
 describe('toOption', () => {
   it('converts Ok to Some', () => expect(toOption(Ok(42))).toEqual(Some(42)));
   it('converts Err to None', () => expect(toOption(Err('e'))).toEqual(None));
+});
+
+describe('ap', () => {
+  const double = (n: number) => n * 2;
+
+  it('applies wrapped function to wrapped value', () => {
+    expect(ap(Ok(double))(Ok(5))).toEqual(Ok(10));
+  });
+
+  it('returns Err when the function is Err', () => {
+    expect(ap(Err<typeof double, string>('no fn'))(Ok(5))).toEqual(Err('no fn'));
+  });
+
+  it('returns Err when the argument is Err', () => {
+    expect(ap(Ok(double))(Err<number, string>('bad val'))).toEqual(Err('bad val'));
+  });
+
+  it('returns the function Err when both are Err (first wins)', () => {
+    expect(ap(Err<typeof double, string>('fn-err'))(Err<number, string>('val-err'))).toEqual(Err('fn-err'));
+  });
+
+  it('composes with mapResult for curried functions', () => {
+    const add = (a: number) => (b: number) => a + b;
+    const addToThree = mapResult(add)(Ok(3));
+    expect(ap(addToThree)(Ok(4))).toEqual(Ok(7));
+  });
+});
+
+describe('liftA2', () => {
+  const add = (a: number, b: number) => a + b;
+
+  it('applies fn when both Results are Ok', () => {
+    expect(liftA2(add)(Ok(3), Ok(4))).toEqual(Ok(7));
+  });
+
+  it('returns the first Err when ra is Err', () => {
+    expect(liftA2(add)(Err<number, string>('x'), Ok(4))).toEqual(Err('x'));
+  });
+
+  it('returns the second Err when only rb is Err', () => {
+    expect(liftA2(add)(Ok(3), Err<number, string>('y'))).toEqual(Err('y'));
+  });
+
+  it('returns the first Err when both are Err', () => {
+    expect(liftA2(add)(Err<number, string>('first'), Err<number, string>('second'))).toEqual(Err('first'));
+  });
+
+  it('works with a real-world combine use case', () => {
+    type User = { name: string; age: number };
+    const makeUser = (name: string, age: number): User => ({ name, age });
+    const parseName = (s: string): Result<string, string> =>
+      s.length > 0 ? Ok(s) : Err('name required');
+    const parseAge = (n: number): Result<number, string> =>
+      n >= 0 ? Ok(n) : Err('age must be non-negative');
+
+    expect(liftA2(makeUser)(parseName('Alice'), parseAge(30))).toEqual(Ok({ name: 'Alice', age: 30 }));
+    expect(liftA2(makeUser)(parseName(''), parseAge(30))).toEqual(Err('name required'));
+  });
+});
+
+describe('liftA3', () => {
+  const sum3 = (a: number, b: number, c: number) => a + b + c;
+
+  it('applies fn when all three Results are Ok', () => {
+    expect(liftA3(sum3)(Ok(1), Ok(2), Ok(3))).toEqual(Ok(6));
+  });
+
+  it('returns the first Err (ra)', () => {
+    expect(liftA3(sum3)(Err<number, string>('a'), Ok(2), Ok(3))).toEqual(Err('a'));
+  });
+
+  it('returns the second Err (rb) when ra is Ok', () => {
+    expect(liftA3(sum3)(Ok(1), Err<number, string>('b'), Ok(3))).toEqual(Err('b'));
+  });
+
+  it('returns the third Err (rc) when ra and rb are Ok', () => {
+    expect(liftA3(sum3)(Ok(1), Ok(2), Err<number, string>('c'))).toEqual(Err('c'));
+  });
+
+  it('returns the first Err when all three fail', () => {
+    expect(liftA3(sum3)(
+      Err<number, string>('first'),
+      Err<number, string>('second'),
+      Err<number, string>('third'),
+    )).toEqual(Err('first'));
+  });
 });


### PR DESCRIPTION
Closes #43

## Context

## Problem

Without applicative combinators, combining multiple independent `Result` values requires awkward nesting or `combineAll` (which loses individual types).

```typescript
// Current: either nested flatMap or losing types ❌
const result = flatMap((a) => flatMap((b) => Ok(a + b))(getB()))(getA());
```

## Functions to add

### `ap`
```typescript
ap<T, E>(resultFn: Result<(a: T) => unknown, E>) => (result: Result<T, E>): Result<unknown, E>
```

Apply a wrapped function to a wrapped value.

### `liftA2`
```typescript
liftA2<A, B, C, E>(
  fn: (a: A, b: B) => C
) => (ra: Result<A, E>, rb: Result<B, E>): Result<C, E>
```

Lift a 2-arg function to work on two Results. Both must be Ok.

```typescript
const add = (a: number, b: number) => a + b;
liftA2(add)(Ok(3), Ok(4))      // Ok(7)
liftA2(add)(Err('x'), Ok(4))   // Err('x')
liftA2(add)(Ok(3), Err('y'))   // Err('y')
```

### `liftA3`
```typescript
liftA3<A, B, C, D, E>(
  fn: (a: A, b: B, c: C) => D
) => (ra: Result<A, E>, rb: Result<B, E>, rc: Result<C, E>): Result<D, E>
```

```typescript
liftA3((a, b, c) => a + b + c)(Ok(1), Ok(2), Ok(3))  // Ok(6)
```

## Use Case

```typescript
// Parse independent fields and combine:
const parseUser = liftA2(
  (name: string, age: number) => ({ name, age })
)(
  parseName(rawName),
  parseAge(rawAge)
);
// Result<User, ParseError> — fails on first error
```

## Notes

- `liftA2` / `liftA3` stop on first error (not accumulate — use `validateAll` for accumulation)
- Export from `src/result.ts` and `src/index.ts`
- Full JSDoc with examples required