### PR TITLE
docs(object): document getPathOr undefined-value behavior and pin with test

### DIFF
--- a/src/_internal/object-access.ts
+++ b/src/_internal/object-access.ts
@@ -131,10 +131,22 @@ export const updatePath =
  * Like {@link getPath} but returns a fallback value instead of `undefined`
  * when the path is missing (curried, data-last).
  *
+ * @remarks
+ * The fallback is returned whenever the resolved value is `undefined` — this
+ * includes the case where a key explicitly exists but its stored value is
+ * `undefined`. This matches the behaviour of `lodash.get` and `Ramda.pathOr`.
+ * Use {@link hasPath} when you need to distinguish "key absent" from
+ * "key present with value `undefined`".
+ *
  * @example
  * const obj = { a: { b: { c: 42 } } };
  * getPathOr(0, ['a', 'b', 'c'])(obj); // 42
- * getPathOr(0, ['a', 'b', 'x'])(obj); // 0
+ * getPathOr(0, ['a', 'b', 'x'])(obj); // 0 — path missing
+ *
+ * // Key exists but value is undefined — fallback is returned
+ * getPathOr(99, ['a'])({ a: undefined }); // 99
+ * // hasPath still reports the key as present:
+ * hasPath(['a'])({ a: undefined }); // true
  */
 export const getPathOr =
   <T>(fallback: T, path: string[]) =>

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -361,6 +361,10 @@ describe('getPathOr', () => {
   it('returns false correctly', () => {
     expect(getPathOr(true, ['flag'])({ flag: false })).toBe(false);
   });
+
+  it('returns fallback when key exists but value is undefined (intentional, matches lodash/Ramda)', () => {
+    expect(getPathOr(99, ['a'])({ a: undefined })).toBe(99);
+  });
 });
 
 describe('hasPath', () => {


### PR DESCRIPTION
Closes #65

## Context

Currently `getPathOr` returns the fallback when the path resolves to `undefined`, even if the key explicitly exists with that value:

```typescript
getPathOr(99, ['a'])({ a: undefined }); // 99 — falls back
```

Meanwhile `hasPath` correctly returns `true` for the same path:
```typescript
hasPath(['a'])({ a: undefined }); // true
```

This inconsistency is the same trade-off made by lodash `_.get` and Ramda `pathOr`.

Action items:
- Add a `@remarks` note to `getPathOr` JSDoc documenting this behaviour
- Add a test case to pin this as intentional: `getPathOr(99, ['a'])({ a: undefined })` → `99`

Ref: found during review of PR #64.