### PR TITLE
chore: rename package to @roxdavirox/fp-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **Functional programming primitives for TypeScript — every type inferred, zero dependencies.**
 
 [![CI](https://github.com/roxdavirox/fp-core/actions/workflows/ci.yml/badge.svg)](https://github.com/roxdavirox/fp-core/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/fp-core)](https://www.npmjs.com/package/fp-core)
-[![Bundle Size](https://img.shields.io/bundlephobia/minzip/fp-core)](https://bundlephobia.com/package/fp-core)
+[![npm](https://img.shields.io/npm/v/@roxdavirox/fp-core)](https://www.npmjs.com/package/@roxdavirox/fp-core)
+[![Bundle Size](https://img.shields.io/bundlephobia/minzip/@roxdavirox/fp-core)](https://bundlephobia.com/package/@roxdavirox/fp-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
 ---
@@ -28,9 +28,9 @@ at every step and zero runtime dependencies.
 ## Install
 
 ```bash
-npm install fp-core
+npm install @roxdavirox/fp-core
 # or
-pnpm add fp-core
+pnpm add @roxdavirox/fp-core
 ```
 
 ---
@@ -38,7 +38,7 @@ pnpm add fp-core
 ## Quick Start
 
 ```typescript
-import { pipe, Ok, Err, Some, None, mapResult, flatMap, match } from 'fp-core';
+import { pipe, Ok, Err, Some, None, mapResult, flatMap, match } from '@roxdavirox/fp-core';
 
 // pipe — fully typed at every step
 const result = pipe(
@@ -64,7 +64,7 @@ pipe(
 );
 
 // Option — nullable without null checks
-import { fromNullable, mapOption, unwrapOptionOr } from 'fp-core';
+import { fromNullable, mapOption, unwrapOptionOr } from '@roxdavirox/fp-core';
 
 const getUser = (id: number) => fromNullable(users.find(u => u.id === id));
 
@@ -95,7 +95,7 @@ pipe(
 ### Safe API call — errors as values, no try/catch
 
 ```typescript
-import { fromPromise, flatMapAsync, match } from 'fp-core';
+import { fromPromise, flatMapAsync, match } from '@roxdavirox/fp-core';
 
 const getUser = async (id: string) => {
   const result = await fromPromise(fetch(`/api/users/${id}`).then(r => r.json()))
@@ -111,7 +111,7 @@ const getUser = async (id: string) => {
 ### Option null-safe navigation — no optional chaining noise
 
 ```typescript
-import { pipe, fromNullable, flatMapOption, mapOption, unwrapOptionOr } from 'fp-core';
+import { pipe, fromNullable, flatMapOption, mapOption, unwrapOptionOr } from '@roxdavirox/fp-core';
 
 const getEventCoords = (user: User): string =>
   pipe(
@@ -126,7 +126,7 @@ const getEventCoords = (user: User): string =>
 ### Form validation — accumulate all errors
 
 ```typescript
-import { Ok, Err, collectErrors, match } from 'fp-core';
+import { Ok, Err, collectErrors, match } from '@roxdavirox/fp-core';
 
 const validate = (form: SignupForm) =>
   match(
@@ -156,17 +156,17 @@ const validate = (form: SignupForm) =>
 
 ## Subpath Imports
 
-fp-core is fully tree-shakeable. Import the root `'fp-core'` for most use cases, or use subpath imports for explicit dependency tracking:
+fp-core is fully tree-shakeable. Import the root `'@roxdavirox/fp-core'` for most use cases, or use subpath imports for explicit dependency tracking:
 
 ```typescript
-import { Ok, Err, flatMap, mapResult } from 'fp-core/result';
-import { Some, None, fromNullable } from 'fp-core/option';
-import { pipe, compose, curry } from 'fp-core/composition';
-import { pipeAsync, retry, timeout } from 'fp-core/async';
-import { map, filter, groupBy } from 'fp-core/array';
-import { pick, omit, setPath } from 'fp-core/object';
-import { camelCase, truncate, template } from 'fp-core/string';
-import { and, or, not, isString } from 'fp-core/predicates';
+import { Ok, Err, flatMap, mapResult } from '@roxdavirox/fp-core/result';
+import { Some, None, fromNullable } from '@roxdavirox/fp-core/option';
+import { pipe, compose, curry } from '@roxdavirox/fp-core/composition';
+import { pipeAsync, retry, timeout } from '@roxdavirox/fp-core/async';
+import { map, filter, groupBy } from '@roxdavirox/fp-core/array';
+import { pick, omit, setPath } from '@roxdavirox/fp-core/object';
+import { camelCase, truncate, template } from '@roxdavirox/fp-core/string';
+import { and, or, not, isString } from '@roxdavirox/fp-core/predicates';
 ```
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,11 +6,11 @@ Complete reference for all exported functions, organized by module.
 
 ```typescript
 // Root barrel — everything
-import { pipe, Ok, Err, Some, None } from 'fp-core';
+import { pipe, Ok, Err, Some, None } from '@roxdavirox/fp-core';
 
 // Subpath — one module
-import { Ok, Err, flatMap } from 'fp-core/result';
-import { pipe, compose } from 'fp-core/composition';
+import { Ok, Err, flatMap } from '@roxdavirox/fp-core/result';
+import { pipe, compose } from '@roxdavirox/fp-core/composition';
 ```
 
 ---
@@ -30,7 +30,7 @@ import { pipe, compose } from 'fp-core/composition';
 
 ## Result\<T, E\>
 
-`import { ... } from 'fp-core/result'`
+`import { ... } from '@roxdavirox/fp-core/result'`
 
 Represents a value that is either a success (`Ok`) or a failure (`Err`).
 Use `Result` instead of throwing exceptions for expected failure paths.
@@ -563,7 +563,7 @@ fromNullableResult('not found')(undefined); // Err('not found')
 
 ## Option\<T\>
 
-`import { ... } from 'fp-core/option'`
+`import { ... } from '@roxdavirox/fp-core/option'`
 
 Represents a value that may or may not be present. Use `Option` to eliminate `null`/`undefined` from your domain types.
 
@@ -856,7 +856,7 @@ resultToOption(Err('oops')); // None
 
 ## Composition
 
-`import { ... } from 'fp-core/composition'`
+`import { ... } from '@roxdavirox/fp-core/composition'`
 
 ### `pipe(value, ...fns)`
 
@@ -1106,7 +1106,7 @@ isOdd(3); // true
 
 ## Async
 
-`import { ... } from 'fp-core/async'`
+`import { ... } from '@roxdavirox/fp-core/async'`
 
 ### `pipeAsync(...fns)(value)`
 
@@ -1343,7 +1343,7 @@ await parallel([
 
 **Example:**
 ```typescript
-import { mapConcurrentResult, mapAsyncResult, collectErrors } from 'fp-core';
+import { mapConcurrentResult, mapAsyncResult, collectErrors } from '@roxdavirox/fp-core';
 
 // mapAsyncResult — sequential, collects all errors
 const results = await mapAsyncResult(
@@ -1362,7 +1362,7 @@ const results2 = await mapConcurrentResult(
 
 ## Array
 
-`import { ... } from 'fp-core/array'`
+`import { ... } from '@roxdavirox/fp-core/array'`
 
 All array functions are curried and data-last — designed to compose inside `pipe`.
 
@@ -1414,7 +1414,7 @@ All array functions are curried and data-last — designed to compose inside `pi
 
 **Example:**
 ```typescript
-import { head, tail, last, nth } from 'fp-core';
+import { head, tail, last, nth } from '@roxdavirox/fp-core';
 
 head([1, 2, 3]); // Some(1)
 head([]);        // None
@@ -1443,7 +1443,7 @@ const [evens, odds] = partition(n => n % 2 === 0)([1, 2, 3, 4]);
 
 ## Object
 
-`import { ... } from 'fp-core/object'`
+`import { ... } from '@roxdavirox/fp-core/object'`
 
 ### Picking & Merging
 
@@ -1523,7 +1523,7 @@ getPath(['db', 'port'])(config); // 5432
 
 ## String
 
-`import { ... } from 'fp-core/string'`
+`import { ... } from '@roxdavirox/fp-core/string'`
 
 ### Case Conversion
 
@@ -1621,7 +1621,7 @@ format('Hello %s, you are %d years old')('Alice', 30);
 
 ## Predicates
 
-`import { ... } from 'fp-core/predicates'`
+`import { ... } from '@roxdavirox/fp-core/predicates'`
 
 ### Logical Combinators
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -29,7 +29,7 @@ import {
   flatMapAsync,
   mapResultAsync,
   match,
-} from 'fp-core';
+} from '@roxdavirox/fp-core';
 
 interface User {
   id: string;
@@ -76,8 +76,8 @@ const getEnrichedUser = async (id: string) => {
 **Use case:** Validate multiple fields, collect all errors at once instead of stopping at the first failure.
 
 ```typescript
-import { Ok, Err, validateAll, collectErrors, match } from 'fp-core';
-import type { Result } from 'fp-core';
+import { Ok, Err, validateAll, collectErrors, match } from '@roxdavirox/fp-core';
+import type { Result } from '@roxdavirox/fp-core';
 
 interface SignupForm {
   email: string;
@@ -121,9 +121,9 @@ const result = validateForm({ email: 'bad', password: 'short', age: 16 });
 **Use case:** Parse and validate a JSON config file without crashing on bad input.
 
 ```typescript
-import { tryCatch, flatMap, unwrapOrElse } from 'fp-core';
-import { Ok, Err } from 'fp-core';
-import type { Result } from 'fp-core';
+import { tryCatch, flatMap, unwrapOrElse } from '@roxdavirox/fp-core';
+import { Ok, Err } from '@roxdavirox/fp-core';
+import type { Result } from '@roxdavirox/fp-core';
 
 interface AppConfig {
   apiUrl: string;
@@ -171,8 +171,8 @@ loadConfig('not json');
 **Use case:** Read a deeply nested value that may not exist at any level without optional chaining.
 
 ```typescript
-import { getPathOr, fromNullable, mapOption, unwrapOptionOr } from 'fp-core';
-import { pipe } from 'fp-core';
+import { getPathOr, fromNullable, mapOption, unwrapOptionOr } from '@roxdavirox/fp-core';
+import { pipe } from '@roxdavirox/fp-core';
 
 interface Address {
   street?: string;
@@ -229,9 +229,9 @@ formatCity('bob');   // 'Unknown city'
 **Use case:** Run multiple async operations concurrently and collect all failures instead of stopping at the first.
 
 ```typescript
-import { mapAsyncResult, collectErrors, match } from 'fp-core';
-import { Ok, Err } from 'fp-core';
-import type { Result } from 'fp-core';
+import { mapAsyncResult, collectErrors, match } from '@roxdavirox/fp-core';
+import { Ok, Err } from '@roxdavirox/fp-core';
+import type { Result } from '@roxdavirox/fp-core';
 
 interface OrderItem {
   productId: string;
@@ -283,8 +283,8 @@ const validation = await validateOrder(order);
 **Use case:** Fetch from an unstable API with automatic retries and exponential backoff.
 
 ```typescript
-import { pipeAsync, retry, match } from 'fp-core';
-import { fromPromise } from 'fp-core';
+import { pipeAsync, retry, match } from '@roxdavirox/fp-core';
+import { fromPromise } from '@roxdavirox/fp-core';
 
 interface ApiResponse {
   data: unknown;
@@ -336,8 +336,8 @@ const processEndpoint = pipeAsync(
 **Use case:** Chain optional property accesses through a deeply nested object without intermediate null checks.
 
 ```typescript
-import { fromNullable, flatMapOption, mapOption, unwrapOptionOr } from 'fp-core';
-import { pipe } from 'fp-core';
+import { fromNullable, flatMapOption, mapOption, unwrapOptionOr } from '@roxdavirox/fp-core';
+import { pipe } from '@roxdavirox/fp-core';
 
 interface Coordinates {
   lat: number;
@@ -396,9 +396,9 @@ formatEventLocation({ name: 'Carol', upcomingEvent: { title: 'Webinar' } });
 **Use case:** Process a batch of items concurrently (bounded concurrency) and surface all failures.
 
 ```typescript
-import { mapConcurrentResult, collectErrors, match } from 'fp-core';
-import { Ok, Err } from 'fp-core';
-import type { Result } from 'fp-core';
+import { mapConcurrentResult, collectErrors, match } from '@roxdavirox/fp-core';
+import { Ok, Err } from '@roxdavirox/fp-core';
+import type { Result } from '@roxdavirox/fp-core';
 
 interface Report {
   userId: string;
@@ -449,9 +449,9 @@ const generateAllReports = async (reports: Report[]) => {
 **Use case:** Transform raw API data through a series of pure functions using `pipe`, array utilities, and object utilities.
 
 ```typescript
-import { pipe } from 'fp-core';
-import { map, filter, sortBy, groupBy } from 'fp-core';
-import { pick, mapValues } from 'fp-core';
+import { pipe } from '@roxdavirox/fp-core';
+import { map, filter, sortBy, groupBy } from '@roxdavirox/fp-core';
+import { pick, mapValues } from '@roxdavirox/fp-core';
 
 interface RawProduct {
   id: string;
@@ -502,9 +502,9 @@ const clientCatalog = pipe(
 **Use case:** Merge user-supplied config over defaults, then validate the result.
 
 ```typescript
-import { defaults, validateAll, match } from 'fp-core';
-import { Ok, Err } from 'fp-core';
-import type { Result } from 'fp-core';
+import { defaults, validateAll, match } from '@roxdavirox/fp-core';
+import { Ok, Err } from '@roxdavirox/fp-core';
+import type { Result } from '@roxdavirox/fp-core';
 
 interface ServerConfig {
   host: string;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fp-core",
+  "name": "@roxdavirox/fp-core",
   "version": "0.1.0",
   "description": "Functional programming primitives for TypeScript — every type inferred, zero dependencies.",
   "type": "module",
@@ -91,6 +91,9 @@
     "url": "https://github.com/roxdavirox/fp-core/issues"
   },
   "homepage": "https://github.com/roxdavirox/fp-core#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.3",
     "@types/node": "^22.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * Zero-dependency. Tree-shakeable. TypeScript-native.
  * Every function is pure, curried, and data-last.
  *
- * @module fp-core
+ * @module @roxdavirox/fp-core
  */
 
 // Result<T, E> — explicit error handling, no exceptions


### PR DESCRIPTION
Renames the npm package from `fp-core` to `@roxdavirox/fp-core` to avoid conflict with an existing abandoned package on npm.

- `package.json`: name updated, `publishConfig.access: public` added (required for scoped packages)
- `README.md`: install command, badges, and all import examples updated
- `docs/API.md`, `docs/RECIPES.md`: all import paths updated
- `src/index.ts`: JSDoc `@module` updated