### PR TITLE
feat(benchmarks): add performance benchmarks vs Ramda, lodash/fp and Remeda

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,40 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  bench:
+    name: Performance benchmarks
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run benchmarks
+        run: npm run bench -- --reporter=verbose 2>&1 | tee bench-results.txt
+
+      - name: Post results to job summary
+        run: |
+          echo "## Benchmark Results" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat bench-results.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results
+          path: bench-results.txt
+          retention-days: 30

--- a/benchmarks/array.bench.ts
+++ b/benchmarks/array.bench.ts
@@ -1,0 +1,108 @@
+import { bench, describe } from 'vitest';
+import * as R from 'ramda';
+import * as L from 'lodash/fp';
+import * as Re from 'remeda';
+import { map, filter, groupBy, chunk } from '../src/array.js';
+
+const NUMBERS = Array.from({ length: 1000 }, (_, i) => i);
+const double = (x: number) => x * 2;
+const isEven = (x: number) => x % 2 === 0;
+
+// ============================================================================
+// map
+// ============================================================================
+
+describe('array.map — 1 000 numbers', () => {
+  bench('fp-core', () => {
+    map(double)(NUMBERS);
+  });
+
+  bench('ramda', () => {
+    R.map(double, NUMBERS);
+  });
+
+  bench('lodash/fp', () => {
+    L.map(double)(NUMBERS);
+  });
+
+  bench('remeda', () => {
+    Re.map(NUMBERS, double);
+  });
+
+  bench('native', () => {
+    NUMBERS.map(double);
+  });
+});
+
+// ============================================================================
+// filter
+// ============================================================================
+
+describe('array.filter — 1 000 numbers', () => {
+  bench('fp-core', () => {
+    filter(isEven)(NUMBERS);
+  });
+
+  bench('ramda', () => {
+    R.filter(isEven, NUMBERS);
+  });
+
+  bench('lodash/fp', () => {
+    L.filter(isEven)(NUMBERS);
+  });
+
+  bench('remeda', () => {
+    Re.filter(NUMBERS, isEven);
+  });
+
+  bench('native', () => {
+    NUMBERS.filter(isEven);
+  });
+});
+
+// ============================================================================
+// groupBy
+// ============================================================================
+
+const WORDS = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+const byLength = (s: string) => String(s.length);
+
+describe('array.groupBy — 10 words', () => {
+  bench('fp-core', () => {
+    groupBy(byLength)(WORDS);
+  });
+
+  bench('ramda', () => {
+    R.groupBy(byLength, WORDS);
+  });
+
+  bench('lodash/fp', () => {
+    L.groupBy(byLength)(WORDS);
+  });
+
+  bench('remeda', () => {
+    Re.groupBy(WORDS, byLength);
+  });
+});
+
+// ============================================================================
+// chunk
+// ============================================================================
+
+describe('array.chunk — 1 000 numbers, size 10', () => {
+  bench('fp-core', () => {
+    chunk(10)(NUMBERS);
+  });
+
+  bench('ramda', () => {
+    R.splitEvery(10, NUMBERS);
+  });
+
+  bench('lodash/fp', () => {
+    L.chunk(10)(NUMBERS);
+  });
+
+  bench('remeda', () => {
+    Re.chunk(NUMBERS, 10);
+  });
+});

--- a/benchmarks/composition.bench.ts
+++ b/benchmarks/composition.bench.ts
@@ -1,0 +1,51 @@
+import { bench, describe } from 'vitest';
+import * as R from 'ramda';
+import * as Re from 'remeda';
+import { pipe, compose } from '../src/composition.js';
+
+// Five arithmetic steps used in every pipeline benchmark
+const add1 = (x: number) => x + 1;
+const double = (x: number) => x * 2;
+const sub3 = (x: number) => x - 3;
+const square = (x: number) => x * x;
+const negate = (x: number) => -x;
+
+// ============================================================================
+// pipe — 5-step, left-to-right
+// ============================================================================
+
+describe('composition.pipe — 5 steps, number', () => {
+  bench('fp-core', () => {
+    pipe(10, add1, double, sub3, square, negate);
+  });
+
+  bench('ramda', () => {
+    R.pipe(add1, double, sub3, square, negate)(10);
+  });
+
+  bench('remeda', () => {
+    Re.pipe(10, add1, double, sub3, square, negate);
+  });
+
+  bench('native', () => {
+    negate(square(sub3(double(add1(10)))));
+  });
+});
+
+// ============================================================================
+// compose — 5-step, right-to-left
+// ============================================================================
+
+describe('composition.compose — 5 steps, number', () => {
+  bench('fp-core', () => {
+    compose(negate, square, sub3, double, add1)(10);
+  });
+
+  bench('ramda', () => {
+    R.compose(negate, square, sub3, double, add1)(10);
+  });
+
+  bench('native', () => {
+    negate(square(sub3(double(add1(10)))));
+  });
+});

--- a/benchmarks/object.bench.ts
+++ b/benchmarks/object.bench.ts
@@ -1,0 +1,106 @@
+import { bench, describe } from 'vitest';
+import * as R from 'ramda';
+import * as L from 'lodash/fp';
+import * as Re from 'remeda';
+import { pick, omit, merge, getPath } from '../src/object.js';
+
+// ============================================================================
+// pick
+// ============================================================================
+
+interface FiveKey { a: number; b: number; c: number; d: number; e: number }
+const OBJ: FiveKey = { a: 1, b: 2, c: 3, d: 4, e: 5 };
+
+describe('object.pick — 5-key object, pick 2', () => {
+  bench('fp-core', () => {
+    pick<FiveKey, 'a' | 'b'>(['a', 'b'])(OBJ);
+  });
+
+  bench('ramda', () => {
+    R.pick(['a', 'b'], OBJ);
+  });
+
+  bench('lodash/fp', () => {
+    L.pick(['a', 'b'])(OBJ);
+  });
+
+  bench('remeda', () => {
+    Re.pick(OBJ, ['a', 'b']);
+  });
+});
+
+// ============================================================================
+// omit
+// ============================================================================
+
+describe('object.omit — 5-key object, omit 2', () => {
+  bench('fp-core', () => {
+    omit<FiveKey, 'd' | 'e'>(['d', 'e'])(OBJ);
+  });
+
+  bench('ramda', () => {
+    R.omit(['d', 'e'], OBJ);
+  });
+
+  bench('lodash/fp', () => {
+    L.omit(['d', 'e'])(OBJ);
+  });
+
+  bench('remeda', () => {
+    Re.omit(OBJ, ['d', 'e']);
+  });
+});
+
+// ============================================================================
+// merge
+// ============================================================================
+
+const BASE = { a: 1, b: 2 };
+const PATCH = { b: 99, c: 3 };
+
+describe('object.merge — shallow merge', () => {
+  bench('fp-core', () => {
+    merge(BASE)(PATCH);
+  });
+
+  bench('ramda', () => {
+    R.mergeRight(BASE, PATCH);
+  });
+
+  bench('lodash/fp', () => {
+    L.merge(BASE)(PATCH);
+  });
+
+  bench('remeda', () => {
+    Re.merge(BASE, PATCH);
+  });
+
+  bench('native', () => {
+    ({ ...BASE, ...PATCH });
+  });
+});
+
+// ============================================================================
+// getPath
+// ============================================================================
+
+interface Nested { user: { profile: { name: string; age: number } } }
+const NESTED: Nested = { user: { profile: { name: 'Alice', age: 30 } } };
+
+describe('object.getPath — 3-level deep access', () => {
+  bench('fp-core', () => {
+    getPath<Nested>(['user', 'profile', 'name'])(NESTED);
+  });
+
+  bench('ramda', () => {
+    R.path(['user', 'profile', 'name'], NESTED);
+  });
+
+  bench('lodash/fp', () => {
+    L.get('user.profile.name')(NESTED);
+  });
+
+  bench('remeda', () => {
+    Re.pathOr(NESTED, ['user', 'profile', 'name'], '');
+  });
+});

--- a/benchmarks/result.bench.ts
+++ b/benchmarks/result.bench.ts
@@ -1,0 +1,107 @@
+import { bench, describe } from 'vitest';
+import { Ok, Err, flatMap, match, combineAll, type Result } from '../src/result.js';
+
+// Competitors (Ramda, lodash, Remeda) have no Result/Either type.
+// The baseline is idiomatic try/catch to show fp-core's overhead vs. raw JS.
+
+// ============================================================================
+// flatMap — chained safe computation
+// ============================================================================
+
+const safeDivide =
+  (n: number) =>
+  (x: number): Result<number, Error> =>
+    x === 0 ? Err(new Error('division by zero')) : Ok(n / x);
+
+describe('result.flatMap — 3 chained operations', () => {
+  bench('fp-core', () => {
+    flatMap(safeDivide(6))(
+      flatMap(safeDivide(100))(Ok<number, Error>(10))
+    );
+  });
+
+  bench('native try/catch', () => {
+    try {
+      const a = 10;
+      const b = 100 / a;
+      const _c = 6 / b;
+    } catch (_) {
+      // ignore
+    }
+  });
+});
+
+// ============================================================================
+// match — pattern matching on result
+// ============================================================================
+
+const okResult: Result<number, Error> = Ok(42);
+const errResult: Result<number, Error> = Err(new Error('oops'));
+
+const matchFns: [(v: number) => string, (e: Error) => string] = [
+  (v) => `value: ${v}`,
+  (e) => `error: ${e.message}`,
+];
+
+describe('result.match — ok branch', () => {
+  bench('fp-core', () => {
+    match(matchFns[0], matchFns[1])(okResult);
+  });
+
+  bench('native ternary', () => {
+    void (okResult.ok
+      ? `value: ${okResult.value}`
+      : `error: ${(okResult as { ok: false; error: Error }).error.message}`);
+  });
+});
+
+describe('result.match — error branch', () => {
+  bench('fp-core', () => {
+    match(matchFns[0], matchFns[1])(errResult);
+  });
+
+  bench('native ternary', () => {
+    void (errResult.ok
+      ? `value: ${(errResult as { ok: true; value: number }).value}`
+      : `error: ${errResult.error.message}`);
+  });
+});
+
+// ============================================================================
+// combineAll — collect results
+// ============================================================================
+
+const OK_RESULTS: Result<number, Error>[] = Array.from({ length: 100 }, (_, i) =>
+  Ok<number, Error>(i),
+);
+const MIXED_RESULTS: Result<number, Error>[] = Array.from({ length: 100 }, (_, i) =>
+  i === 50 ? Err<number, Error>(new Error('fail')) : Ok<number, Error>(i),
+);
+
+describe('result.combineAll — 100 Ok results', () => {
+  bench('fp-core', () => {
+    combineAll(OK_RESULTS);
+  });
+
+  bench('native loop', () => {
+    const values: number[] = [];
+    for (const r of OK_RESULTS) {
+      if (!r.ok) return;
+      values.push(r.value);
+    }
+  });
+});
+
+describe('result.combineAll — 100 results, 1 error at index 50', () => {
+  bench('fp-core', () => {
+    combineAll(MIXED_RESULTS);
+  });
+
+  bench('native loop', () => {
+    const values: number[] = [];
+    for (const r of MIXED_RESULTS) {
+      if (!r.ok) return;
+      values.push(r.value);
+    }
+  });
+});

--- a/benchmarks/string.bench.ts
+++ b/benchmarks/string.bench.ts
@@ -1,0 +1,73 @@
+import { bench, describe } from 'vitest';
+import * as L from 'lodash/fp';
+import { camelCase, truncate, format, template } from '../src/string.js';
+
+// lodash/fp has camelCase and truncate; no direct format equivalent.
+// Remeda has no string utilities — excluded from this module.
+
+// ============================================================================
+// camelCase
+// ============================================================================
+
+const SNAKE = 'hello_world_foo_bar';
+
+describe('string.camelCase', () => {
+  bench('fp-core', () => {
+    camelCase(SNAKE);
+  });
+
+  bench('lodash/fp', () => {
+    L.camelCase(SNAKE);
+  });
+});
+
+// ============================================================================
+// truncate
+// ============================================================================
+
+const LONG = 'The quick brown fox jumps over the lazy dog near the riverbank';
+
+describe('string.truncate — 30 chars', () => {
+  bench('fp-core', () => {
+    truncate(30)(LONG);
+  });
+
+  bench('lodash/fp', () => {
+    L.truncate({ length: 30 })(LONG);
+  });
+});
+
+// ============================================================================
+// format — printf-style %s/%d
+// ============================================================================
+
+const FMT = 'Hello %s, you are %d years old';
+
+describe('string.format — 2 printf placeholders', () => {
+  bench('fp-core', () => {
+    format(FMT)('Alice', 30);
+  });
+
+  bench('native replace', () => {
+    let i = 0;
+    const args = ['Alice', 30];
+    FMT.replace(/%[sd]/g, () => String(args[i++]));
+  });
+});
+
+// ============================================================================
+// template — {{key}} interpolation
+// ============================================================================
+
+const TMPL = 'Hello {{name}}, you have {{count}} messages.';
+const VALS = { name: 'Alice', count: 5 };
+
+describe('string.template — 2 key interpolations', () => {
+  bench('fp-core', () => {
+    template(VALS)(TMPL);
+  });
+
+  bench('native replace', () => {
+    TMPL.replace(/\{\{(\w+)\}\}/g, (_, k) => String((VALS as Record<string, unknown>)[k] ?? ''));
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,25 @@
 {
-  "name": "fp-core",
+  "name": "@roxdavirox/fp-core",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fp-core",
+      "name": "@roxdavirox/fp-core",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.3",
+        "@types/lodash": "^4.17.24",
         "@types/node": "^22.0.0",
+        "@types/ramda": "^0.31.1",
         "@vitest/coverage-v8": "^3.0.0",
         "eslint": "^9.39.3",
         "husky": "^9.1.7",
         "lint-staged": "^15.5.2",
+        "lodash": "^4.17.23",
+        "ramda": "^0.32.0",
+        "remeda": "^2.33.6",
         "typescript": "^5.9.0",
         "typescript-eslint": "^8.56.1",
         "vitest": "^3.0.0"
@@ -1257,6 +1262,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
@@ -1265,6 +1277,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ramda": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.31.1.tgz",
+      "integrity": "sha512-Vt6sFXnuRpzaEj+yeutA0q3bcAsK7wdPuASIzR9LXqL4gJPyFw8im9qchlbp4ltuf3kDEIRmPJTD/Fkg60dn7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "types-ramda": "^0.31.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3014,6 +3036,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3539,6 +3568,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/ramda": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/remeda": {
+      "version": "2.33.6",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.6.tgz",
+      "integrity": "sha512-tazDGH7s75kUPGBKLvhgBEHMgW+TdDFhjUAMdQj57IoWz6HsGa5D2RX5yDUz6IIqiRRvZiaEHzCzWdTeixc/Kg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remeda"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4019,6 +4069,13 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4030,6 +4087,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/types-ramda": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.31.0.tgz",
+      "integrity": "sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "bench": "vitest bench",
     "clean": "rm -rf dist",
     "prepare": "husky"
   },
@@ -96,11 +97,16 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",
+    "@types/lodash": "^4.17.24",
     "@types/node": "^22.0.0",
+    "@types/ramda": "^0.31.1",
     "@vitest/coverage-v8": "^3.0.0",
     "eslint": "^9.39.3",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.2",
+    "lodash": "^4.17.23",
+    "ramda": "^0.32.0",
+    "remeda": "^2.33.6",
     "typescript": "^5.9.0",
     "typescript-eslint": "^8.56.1",
     "vitest": "^3.0.0"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,5 +17,8 @@ export default defineConfig({
         statements: 90,
       },
     },
+    benchmark: {
+      include: ['benchmarks/**/*.bench.ts'],
+    },
   },
 });


### PR DESCRIPTION
Closes #45

## Context

## Problem

No way to measure performance regressions or compare against alternatives. Makes it hard to justify fp-core in performance-sensitive contexts.

## Deliverables

### Benchmark suite (`benchmarks/`)

Using [vitest bench](https://vitest.dev/guide/features#benchmarking) (already available via vitest):

```
benchmarks/
├── array.bench.ts
├── object.bench.ts
├── string.bench.ts
├── composition.bench.ts
└── result.bench.ts
```

### Competitors to compare

- **Ramda** — functional, curried
- **lodash/fp** — functional lodash
- **Remeda** — TypeScript-first

Install as `devDependencies` only.

### Functions to benchmark

| Module | Functions |
|--------|-----------|
| array | `map`, `filter`, `groupBy`, `chunk` |
| object | `pick`, `omit`, `merge`, `getPath` |
| string | `camelCase`, `truncate`, `format` |
| composition | `pipe` (5-step), `compose` |
| result | `flatMap`, `match`, `combineAll` |

### package.json script

```json
"bench": "vitest bench"
```

### CI integration

Add optional benchmark job (not blocking) to CI that posts results as PR comment.

## Notes

- Benchmarks live in `benchmarks/` (excluded from npm publish via `files`)
- Should run on `main` only (not every PR — too slow)
- Results don't need to beat Ramda/lodash on every operation, just be competitive