### PR TITLE
fix(string): normalize snakeCase and kebabCase to accept any input format

### DIFF
--- a/src/_internal/string-transform.ts
+++ b/src/_internal/string-transform.ts
@@ -122,30 +122,41 @@ export const pascalCase = (str: string): string => {
 };
 
 /**
+ * Splits a string into lowercase words.
+ * Handles camelCase, PascalCase, kebab-case, snake_case, Title Case,
+ * and any combination of these formats.
+ */
+const splitWords = (str: string): string[] =>
+  str
+    .replace(/([a-z])([A-Z])/g, '$1 $2')       // camelCase → "camel Case"
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2') // XMLParser → "XML Parser"
+    .split(/[\s_-]+/)
+    .map(w => w.toLowerCase())
+    .filter(Boolean);
+
+/**
  * Converts a string to snake_case.
+ * Accepts any common format: camelCase, PascalCase, kebab-case, space-separated.
  *
  * @example
- * snakeCase('helloWorld'); // 'hello_world'
+ * snakeCase('helloWorld');   // 'hello_world'
+ * snakeCase('hello-world');  // 'hello_world'
+ * snakeCase('Hello World');  // 'hello_world'
+ * snakeCase('XMLParser');    // 'xml_parser'
  */
-export const snakeCase = (str: string): string =>
-  str
-    .replace(/([A-Z])/g, '_$1')
-    .toLowerCase()
-    .replace(/^_/, '')
-    .replace(/\s+/g, '_');
+export const snakeCase = (str: string): string => splitWords(str).join('_');
 
 /**
  * Converts a string to kebab-case.
+ * Accepts any common format: camelCase, PascalCase, snake_case, space-separated.
  *
  * @example
- * kebabCase('helloWorld'); // 'hello-world'
+ * kebabCase('helloWorld');   // 'hello-world'
+ * kebabCase('hello_world');  // 'hello-world'
+ * kebabCase('Hello World');  // 'hello-world'
+ * kebabCase('XMLParser');    // 'xml-parser'
  */
-export const kebabCase = (str: string): string =>
-  str
-    .replace(/([A-Z])/g, '-$1')
-    .toLowerCase()
-    .replace(/^-/, '')
-    .replace(/\s+/g, '-');
+export const kebabCase = (str: string): string => splitWords(str).join('-');
 
 /**
  * Capitalizes the first letter of each word.

--- a/tests/string.test.ts
+++ b/tests/string.test.ts
@@ -31,12 +31,28 @@ describe('case transformations', () => {
     expect(pascalCase('hello world')).toBe('HelloWorld');
   });
 
-  it('snakeCase from camelCase', () => {
-    expect(snakeCase('helloWorld')).toBe('hello_world');
+  describe('snakeCase', () => {
+    it('from camelCase', () => expect(snakeCase('helloWorld')).toBe('hello_world'));
+    it('from PascalCase', () => expect(snakeCase('HelloWorld')).toBe('hello_world'));
+    it('from kebab-case', () => expect(snakeCase('hello-world')).toBe('hello_world'));
+    it('from space-separated', () => expect(snakeCase('hello world')).toBe('hello_world'));
+    it('from Title Case', () => expect(snakeCase('Hello World')).toBe('hello_world'));
+    it('from ALL_CAPS_SNAKE', () => expect(snakeCase('HELLO_WORLD')).toBe('hello_world'));
+    it('from uppercase acronym', () => expect(snakeCase('XMLParser')).toBe('xml_parser'));
+    it('from mixed delimiters', () => expect(snakeCase('hello-world_test')).toBe('hello_world_test'));
+    it('already snake_case is idempotent', () => expect(snakeCase('hello_world')).toBe('hello_world'));
   });
 
-  it('kebabCase from camelCase', () => {
-    expect(kebabCase('helloWorld')).toBe('hello-world');
+  describe('kebabCase', () => {
+    it('from camelCase', () => expect(kebabCase('helloWorld')).toBe('hello-world'));
+    it('from PascalCase', () => expect(kebabCase('HelloWorld')).toBe('hello-world'));
+    it('from snake_case', () => expect(kebabCase('hello_world')).toBe('hello-world'));
+    it('from space-separated', () => expect(kebabCase('hello world')).toBe('hello-world'));
+    it('from Title Case', () => expect(kebabCase('Hello World')).toBe('hello-world'));
+    it('from ALL_CAPS_SNAKE', () => expect(kebabCase('HELLO_WORLD')).toBe('hello-world'));
+    it('from uppercase acronym', () => expect(kebabCase('XMLParser')).toBe('xml-parser'));
+    it('from mixed delimiters', () => expect(kebabCase('hello_world-test')).toBe('hello-world-test'));
+    it('already kebab-case is idempotent', () => expect(kebabCase('hello-world')).toBe('hello-world'));
   });
 
   it('titleCase', () => {


### PR DESCRIPTION
Closes #79

## Context

## Problem

`snakeCase` and `kebabCase` are implemented by detecting uppercase letters and inserting a separator before them. This only works correctly for camelCase input. Other common input formats produce wrong output:

```ts
// snakeCase
snakeCase('hello-world');   // 'hello-world' (should be 'hello_world')
snakeCase('Hello World');   // '_hello _world' (leading underscore, wrong)
snakeCase('__leading');     // '___leading' (double underscore)

// kebabCase
kebabCase('hello_world');   // 'hello_world' (should be 'hello-world')
kebabCase('Hello World');   // '-hello -world' (leading dash, wrong)
```

Current implementation:
```ts
export const snakeCase = (str: string): string =>
  str
    .replace(/([A-Z])/g, '_$1')   // only handles camelCase
    .toLowerCase()
    .replace(/^_/, '')
    .replace(/\s+/g, '_');        // handles spaces, but _after_ the uppercase step
```

## Expected behaviour

Both functions should accept any casing convention as input (camelCase, PascalCase, kebab-case, snake_case, `Title Case`, space-separated) and produce the correct output format.

## Files

- `src/_internal/string-transform.ts` — lines 130–148