### PR TITLE
fix(object): equals now correctly compares nested arrays-of-arrays

### DIFF
--- a/src/_internal/object-access.ts
+++ b/src/_internal/object-access.ts
@@ -214,6 +214,20 @@ export const deletePath =
  */
 export const isEmpty = <T extends object>(obj: T): boolean => Object.keys(obj).length === 0;
 
+/** Recursive value equality used internally by equals. */
+const equalsValue = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!equalsValue(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (isObject(a) && isObject(b)) return equals(a)(b);
+  return false;
+};
+
 /**
  * Structural equality comparison for two plain objects (curried, data-last).
  *
@@ -239,18 +253,7 @@ export const equals =
       const val1 = (obj1 as Record<string, unknown>)[key];
       const val2 = (obj2 as Record<string, unknown>)[key];
 
-      if (isObject(val1) && isObject(val2)) {
-        if (!equals(val1)(val2)) return false;
-      } else if (Array.isArray(val1) && Array.isArray(val2)) {
-        if (val1.length !== val2.length) return false;
-        for (let i = 0; i < val1.length; i++) {
-          if (isObject(val1[i]) && isObject(val2[i])) {
-            if (!equals(val1[i])(val2[i])) return false;
-          } else if (val1[i] !== val2[i]) {
-            return false;
-          }
-        }
-      } else if (val1 !== val2) {
+      if (!equalsValue(val1, val2)) {
         return false;
       }
     }

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -215,6 +215,21 @@ describe('equals', () => {
   it('returns false for arrays of different length', () => {
     expect(equals({ list: [1, 2, 3] })({ list: [1, 2] })).toBe(false);
   });
+
+  it('handles nested arrays-of-arrays', () => {
+    expect(equals({ a: [[1, 2], [3, 4]] })({ a: [[1, 2], [3, 4]] })).toBe(true);
+    expect(equals({ a: [[1, 2]] })({ a: [[1, 9]] })).toBe(false);
+  });
+
+  it('handles deeply nested arrays', () => {
+    expect(equals({ a: [[[1]]] })({ a: [[[1]]] })).toBe(true);
+    expect(equals({ a: [[[1]]] })({ a: [[[2]]] })).toBe(false);
+  });
+
+  it('returns true for same reference', () => {
+    const obj = { a: 1 };
+    expect(equals(obj)(obj)).toBe(true);
+  });
 });
 
 describe('clone', () => {


### PR DESCRIPTION
Closes #78

## Context

## Problem

`equals` in `src/_internal/object-access.ts` compares arrays inside objects, but only one level deep — it does not recurse into nested arrays.

```ts
} else if (Array.isArray(val1) && Array.isArray(val2)) {
  if (val1.length !== val2.length) return false;
  for (let i = 0; i < val1.length; i++) {
    if (isObject(val1[i]) && isObject(val2[i])) {
      if (!equals(val1[i])(val2[i])) return false;
    } else if (val1[i] !== val2[i]) {
      return false;  // ← nested arrays compared with ===, always false for distinct refs
    }
  }
}
```

## Failing cases

```ts
equals({ a: [[1, 2]] })({ a: [[1, 2]] }); // false (should be true)
equals({ a: [{ x: 1 }] })({ a: [{ x: 2 }] }); // true (should be false — only compares [0] !== [0] as refs)
```

## Notes

`deepEquals` handles this correctly. The issue is in `equals`, which is documented as a "plain object" comparison but should still correctly handle array values at any depth, given it already attempts to recurse into arrays.

Consider delegating the array comparison to the same recursive logic, or clearly documenting that `equals` is shallow for array elements and users should prefer `deepEquals`.

## Files

- `src/_internal/object-access.ts` — lines 228–259