### PR TITLE
fix(async): remove dead code in throttleAsync; reject superseded promises in debounceAsync

### DIFF
--- a/src/_internal/async-control.ts
+++ b/src/_internal/async-control.ts
@@ -88,6 +88,7 @@ export const debounceAsync =
     return (...args: T): Promise<R> => {
       if (timeoutId) {
         clearTimeout(timeoutId);
+        latestReject?.(new Error('debounced'));
       }
 
       return new Promise<R>((resolve, reject) => {
@@ -95,6 +96,7 @@ export const debounceAsync =
         latestReject = reject;
 
         timeoutId = setTimeout(async () => {
+          timeoutId = null;
           try {
             const result = await fn(...args);
             latestResolve?.(result);
@@ -126,21 +128,15 @@ export const throttleAsync =
     let lastExecution = 0;
     let pending: Promise<R> | null = null;
 
-    return async (...args: T): Promise<R> => {
+    return (...args: T): Promise<R> => {
       const now = Date.now();
-      const timeSinceLastExecution = now - lastExecution;
 
-      if (timeSinceLastExecution >= delayMs) {
+      if (now - lastExecution >= delayMs || pending === null) {
         lastExecution = now;
         pending = fn(...args);
-        return pending;
+        void pending.finally(() => { pending = null; });
       }
 
-      if (pending) {
-        return pending;
-      }
-
-      pending = fn(...args);
       return pending;
     };
   };

--- a/tests/async.test.ts
+++ b/tests/async.test.ts
@@ -163,13 +163,24 @@ describe('debounceAsync', () => {
     const inner = vi.fn(async (n: number) => n * 2);
     const debounced = debounceAsync<[number], number>(50)(inner as NumFn);
 
-    debounced(1);
-    debounced(2);
+    debounced(1).catch(() => {}); // superseded — rejects with 'debounced'
+    debounced(2).catch(() => {}); // superseded — rejects with 'debounced'
     const result = await debounced(3);
 
     expect(result).toBe(6);
     expect(inner).toHaveBeenCalledTimes(1);
     expect(inner).toHaveBeenCalledWith(3);
+  });
+
+  it('rejects superseded calls with a debounced error', async () => {
+    const inner = vi.fn(async (n: number) => n * 2);
+    const debounced = debounceAsync<[number], number>(50)(inner as NumFn);
+
+    const p1 = debounced(1);
+    p1.catch(() => {}); // attach handler before rejection fires to suppress unhandled-rejection warning
+    await debounced(2); // supersedes p1 — p1 rejects synchronously with Error('debounced')
+
+    await expect(p1).rejects.toThrow('debounced');
   });
 
   it('calls the function again after the delay has elapsed', async () => {
@@ -230,6 +241,19 @@ describe('throttleAsync', () => {
     const result = await throttled(2);
 
     expect(result).toBe(4);
+    expect(inner).toHaveBeenCalledTimes(2);
+  });
+
+  it('executes fresh when promise settled and window expired', async () => {
+    const inner = vi.fn(async (n: number) => n * 2);
+    const throttled = throttleAsync<[number], number>(20)(inner as NumFn);
+
+    const r1 = await throttled(3); // executes, pending set then cleared after settle
+    await sleep(30);               // window expires
+    const r2 = await throttled(5); // new window — must execute fresh
+
+    expect(r1).toBe(6);
+    expect(r2).toBe(10);
     expect(inner).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

- **throttleAsync** (#76): the final `pending = fn(...args)` branch was unreachable (`timeSince < delayMs` always implies `pending !== null` in the original). Removed dead code. Added `.finally()` to reset `pending` after settlement so calls that arrive after the promise settles but within the window get a fresh execution cleanly.
- **debounceAsync** (#77): superseded promises (from calls cancelled by a newer call) were abandoned — they would hang forever, leaking memory and breaking `await` semantics. Now the previous promise is rejected with `Error('debounced')` when a newer call supersedes it. Also resets `timeoutId = null` after the timer fires for defensive cleanup.

## Test plan

- [x] All 427 existing tests pass
- [x] New test: `debounceAsync` — `rejects superseded calls with a debounced error`
- [x] New test: `throttleAsync` — `executes fresh when promise settled and window expired`
- [x] ESLint + tsc clean

Closes #76
Closes #77