### PR TITLE
fix(docs): translate Portuguese JSDoc comments in result.ts to English

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -91,7 +91,7 @@ export const mapErr =
     isErr(result) ? Err(fn(result.error)) : result;
 
 /**
- * FlatMap (bind/chain) - permite encadear operações que retornam Result
+ * FlatMap (bind/chain) — chains operations that return Result
  *
  * @example
  * const divide = (x: number, y: number): Result<number, string> =>
@@ -111,7 +111,7 @@ export const flatMap =
 export const andThen = flatMap;
 
 /**
- * Unwrap - extrai valor ou lança erro
+ * Unwrap — extracts the value or throws the error
  *
  * @example
  * unwrap(Ok(42)); // 42


### PR DESCRIPTION
## Summary

- Two JSDoc descriptions in `src/result.ts` were written in Portuguese, violating the project convention (all source comments in English)
- `flatMap`: `"permite encadear operações que retornam Result"` → `"chains operations that return Result"`
- `unwrap`: `"extrai valor ou lança erro"` → `"extracts the value or throws the error"`

## Test plan

- [x] No logic changes — all 427 tests pass
- [x] ESLint + tsc clean
- [x] No Portuguese text remaining in `src/`

Closes #80