### PR TITLE
refactor(object,predicates): Object.keys in clone/freeze; early-exit counter in xor

### DIFF
--- a/src/_internal/object-access.ts
+++ b/src/_internal/object-access.ts
@@ -288,10 +288,8 @@ export const clone = <T>(obj: T): T => {
 
   if (obj instanceof Object) {
     const clonedObj: Record<string, unknown> = {};
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        clonedObj[key] = clone((obj as Record<string, unknown>)[key]);
-      }
+    for (const key of Object.keys(obj)) {
+      clonedObj[key] = clone((obj as Record<string, unknown>)[key]);
     }
     return clonedObj as T;
   }
@@ -462,12 +460,10 @@ export const deepClone = <T>(value: T): T => deepCopy(value, new Map()) as T;
 export const freeze = <T extends object>(obj: T): Readonly<T> => {
   Object.freeze(obj);
 
-  for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      const value = obj[key];
-      if (isObject(value)) {
-        freeze(value);
-      }
+  for (const key of Object.keys(obj)) {
+    const value = obj[key as keyof T];
+    if (isObject(value)) {
+      freeze(value);
     }
   }
 

--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -104,7 +104,11 @@ export const or =
 export const xor =
   <T>(...predicates: Array<(value: T) => boolean>) =>
   (value: T): boolean => {
-    const trueCount = predicates.filter(p => p(value)).length;
+    let trueCount = 0;
+    for (const p of predicates) {
+      if (p(value)) trueCount += 1;
+      if (trueCount > 1) return false;
+    }
     return trueCount === 1;
   };
 


### PR DESCRIPTION
## Summary

- **clone / freeze** (#91): `for...in` iterates inherited properties and required an explicit `hasOwnProperty` guard on every iteration. Replaced with `Object.keys()` which returns only own enumerable keys, making the intent clear and removing the guard boilerplate.
- **xor** (#92): `filter(...).length` builds a temporary array for the sole purpose of counting truthy results. Replaced with a counter that short-circuits as soon as `trueCount > 1`, avoiding both the allocation and any unnecessary predicate evaluations.

## Test plan

- [x] All 427 tests pass
- [x] ESLint + tsc clean

Closes #91
Closes #92