### PR TITLE
refactor(array): replace unsafe unknown[]→T[] cast in flattenDeep with NestedArray<T>

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -224,13 +224,20 @@ export const partition =
  */
 export const flatten = <T>(arr: T[][]): T[] => arr.flat();
 
+/** Recursive type that describes a nested array whose leaves are all of type `T`. */
+type NestedArray<T> = Array<T | NestedArray<T>>;
+
 /**
  * Recursively flattens a deeply nested array.
  *
  * @example
  * flattenDeep([1, [2, [3, [4, [5]]]]]); // [1, 2, 3, 4, 5]
  */
-export const flattenDeep = <T>(arr: unknown[]): T[] => arr.flat(Infinity) as T[];
+export const flattenDeep = <T>(arr: NestedArray<T>): T[] =>
+  // TypeScript cannot evaluate flat(Infinity) on a self-referential type; the any[]
+  // cast is the minimal escape hatch — the output guarantee is preserved by NestedArray<T>.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (arr as any[]).flat(Infinity) as T[];
 
 /**
  * Combines two arrays into an array of tuples, truncated to the shorter length.


### PR DESCRIPTION
## Summary

`flattenDeep` accepted `unknown[]` as input and unconditionally cast the result to `T[]`, letting callers pass any array and silently get a wrongly-typed output.

The input is now typed as `NestedArray<T> = Array<T | NestedArray<T>>`, a recursive alias that constrains all leaf values to `T`. This makes the internal `T[]` cast semantically sound: if the input satisfies `NestedArray<T>`, every leaf is guaranteed to be `T`.

TypeScript cannot evaluate `.flat(Infinity)` on self-referential types (TS2589), so a minimal `any[]` bridge is used internally with an explanatory comment — this is the standard escape hatch for this class of TypeScript limitation.

## Test plan

- [x] All 427 tests pass
- [x] ESLint + tsc clean (no unused-disable warnings)

Closes #88