### PR TITLE
fix(string): rewrite camelCase/pascalCase using splitWords — fix uppercase-sequence handling

### DIFF
--- a/src/_internal/string-transform.ts
+++ b/src/_internal/string-transform.ts
@@ -101,27 +101,6 @@ export const capitalize = (str: string): string =>
   str.length === 0 ? str : str[0]!.toUpperCase() + str.slice(1).toLowerCase();
 
 /**
- * Converts a string to camelCase.
- *
- * @example
- * camelCase('hello world'); // 'helloWorld'
- * camelCase('hello_world'); // 'helloWorld'
- */
-export const camelCase = (str: string): string =>
-  str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
-
-/**
- * Converts a string to PascalCase.
- *
- * @example
- * pascalCase('hello world'); // 'HelloWorld'
- */
-export const pascalCase = (str: string): string => {
-  const camel = camelCase(str);
-  return camel.length === 0 ? camel : camel[0]!.toUpperCase() + camel.slice(1);
-};
-
-/**
  * Splits a string into lowercase words.
  * Handles camelCase, PascalCase, kebab-case, snake_case, Title Case,
  * and any combination of these formats.
@@ -133,6 +112,35 @@ const splitWords = (str: string): string[] =>
     .split(/[\s_-]+/)
     .map(w => w.toLowerCase())
     .filter(Boolean);
+
+/**
+ * Converts a string to camelCase.
+ * Accepts any common format: PascalCase, snake_case, kebab-case, space-separated.
+ *
+ * @example
+ * camelCase('hello world'); // 'helloWorld'
+ * camelCase('hello_world'); // 'helloWorld'
+ * camelCase('XMLParser');   // 'xmlParser'
+ * camelCase('getHTTPSUrl'); // 'getHttpsUrl'
+ */
+export const camelCase = (str: string): string => {
+  const ws = splitWords(str);
+  if (ws.length === 0) return '';
+  return ws[0]! + ws.slice(1).map(w => w[0]!.toUpperCase() + w.slice(1)).join('');
+};
+
+/**
+ * Converts a string to PascalCase.
+ * Accepts any common format: camelCase, snake_case, kebab-case, space-separated.
+ *
+ * @example
+ * pascalCase('hello world'); // 'HelloWorld'
+ * pascalCase('XMLParser');   // 'XmlParser'
+ */
+export const pascalCase = (str: string): string => {
+  const camel = camelCase(str);
+  return camel.length === 0 ? camel : camel[0]!.toUpperCase() + camel.slice(1);
+};
 
 /**
  * Converts a string to snake_case.

--- a/tests/string.test.ts
+++ b/tests/string.test.ts
@@ -19,16 +19,20 @@ describe('case transformations', () => {
     expect(capitalize('hELLO wORLD')).toBe('Hello world');
   });
 
-  it('camelCase from space-separated', () => {
-    expect(camelCase('hello world')).toBe('helloWorld');
+  describe('camelCase', () => {
+    it('from space-separated', () => expect(camelCase('hello world')).toBe('helloWorld'));
+    it('from underscore-separated', () => expect(camelCase('hello_world')).toBe('helloWorld'));
+    it('from kebab-case', () => expect(camelCase('hello-world')).toBe('helloWorld'));
+    it('from PascalCase', () => expect(camelCase('HelloWorld')).toBe('helloWorld'));
+    it('from uppercase acronym', () => expect(camelCase('XMLParser')).toBe('xmlParser'));
+    it('from mixed uppercase sequence', () => expect(camelCase('getHTTPSUrl')).toBe('getHttpsUrl'));
+    it('already camelCase is idempotent', () => expect(camelCase('helloWorld')).toBe('helloWorld'));
   });
 
-  it('camelCase from underscore-separated', () => {
-    expect(camelCase('hello_world')).toBe('helloWorld');
-  });
-
-  it('pascalCase', () => {
-    expect(pascalCase('hello world')).toBe('HelloWorld');
+  describe('pascalCase', () => {
+    it('from space-separated', () => expect(pascalCase('hello world')).toBe('HelloWorld'));
+    it('from uppercase acronym', () => expect(pascalCase('XMLParser')).toBe('XmlParser'));
+    it('from camelCase', () => expect(pascalCase('helloWorld')).toBe('HelloWorld'));
   });
 
   describe('snakeCase', () => {


### PR DESCRIPTION
## Summary

The regex-based `camelCase` lowercased the entire string first, then only capitalised the character after a non-alphanumeric boundary. This meant uppercase sequences (acronyms) produced incorrect output:

```ts
// Before
camelCase('XMLParser')   // 'xmlparser'  ← wrong
camelCase('getHTTPSUrl') // 'gethttpsurl' ← wrong

// After
camelCase('XMLParser')   // 'xmlParser'  ✓
camelCase('getHTTPSUrl') // 'getHttpsUrl' ✓
```

**Fix:** reuse the same `splitWords` helper already used by `snakeCase` and `kebabCase`. Moved `splitWords` above `camelCase`/`pascalCase` so it is in scope. `pascalCase` continues to delegate to `camelCase` unchanged.

## Test plan

- [x] All 434 tests pass (7 new camelCase / pascalCase tests added)
- [x] ESLint + tsc clean
- [x] Existing camelCase tests still pass (space-separated, underscore-separated)

Closes #90