### PR TITLE
docs: add @param/@returns JSDoc to complex multi-parameter functions

### DIFF
--- a/src/_internal/async-control.ts
+++ b/src/_internal/async-control.ts
@@ -13,6 +13,11 @@ import { Ok, Err, type Result } from '../result.js';
  * Retries an async function with exponential backoff.
  * Returns `Result<T, Error>` — never throws.
  *
+ * @param maxAttempts - Number of times to attempt the function before giving up.
+ * @param delayMs - Base delay in milliseconds between attempts (default: 1000).
+ * @param backoff - Exponential multiplier applied to `delayMs` on each retry (default: 2).
+ * @returns `Ok(value)` on first success; `Err(lastError)` after all attempts fail.
+ *
  * @example
  * const result = await retry(3, 1000)(fetchData); // 3 attempts, 1s base delay
  * if (!result.ok) console.error(result.error.message);

--- a/src/_internal/fn-utils.ts
+++ b/src/_internal/fn-utils.ts
@@ -109,6 +109,11 @@ export const tap =
 /**
  * Caches the results of a pure function keyed by its arguments.
  *
+ * @param fn - The function whose results should be cached. Should be pure (same args → same result).
+ * @param keyFn - Produces the cache key from the arguments (default: `JSON.stringify(args)`).
+ *   Use a custom `keyFn` when args contain non-serialisable values (e.g. objects by reference).
+ * @returns A memoized wrapper that returns cached results on repeated calls with equal keys.
+ *
  * @example
  * const slowFn = (n: number) => n * 2;
  * const fastFn = memoize(slowFn);

--- a/src/_internal/object-access.ts
+++ b/src/_internal/object-access.ts
@@ -84,6 +84,12 @@ export const getPath =
  * Returns a new object with the value at the given path replaced.
  * Does not mutate the original (curried, data-last).
  *
+ * @param path - Array of keys describing the nested location to write.
+ *   An empty path returns the object unchanged.
+ * @param value - The new value to set at the path. Intermediate objects are
+ *   created as `{}` if a segment is missing or non-object.
+ * @returns A structurally-shared copy of the input with the path updated.
+ *
  * @example
  * const user = { profile: { name: 'Alice' } };
  * setPath(['profile', 'name'], 'Bob')(user);

--- a/src/_internal/string-transform.ts
+++ b/src/_internal/string-transform.ts
@@ -246,6 +246,11 @@ export const reverse = (str: string): string => Array.from(str).reverse().join('
 /**
  * Truncates a string to the given length, appending a suffix if cut.
  *
+ * @param maxLength - Maximum length of the returned string including the suffix.
+ * @param suffix - String appended when truncation occurs (default: `'...'`).
+ * @returns The original string if `str.length <= maxLength`, otherwise the
+ *   truncated string with the suffix appended.
+ *
  * @example
  * truncate(10)('hello world'); // 'hello w...'
  * truncate(10, '…')('hello world'); // 'hello wor…'

--- a/src/array.ts
+++ b/src/array.ts
@@ -275,6 +275,9 @@ export const unzip = <T, U>(arr: Array<[T, U]>): [T[], U[]] => {
 /**
  * Splits an array into chunks of a given size (curried, data-last).
  *
+ * @param size - Number of elements per chunk. Must be ≥ 1; values ≤ 0 produce an empty array.
+ * @returns A new array of sub-arrays. The last chunk may be smaller than `size`.
+ *
  * @example
  * chunk(2)([1, 2, 3, 4, 5]); // [[1, 2], [3, 4], [5]]
  */

--- a/src/result.ts
+++ b/src/result.ts
@@ -511,7 +511,12 @@ export const flatMapAsync =
 export type Validator<T, E = string> = (value: T) => Result<T, E>;
 
 /**
- * Combines multiple validators - all must pass
+ * Combines multiple validators — all must pass (fail-fast).
+ *
+ * @param validators - Array of validator functions. Checked in order; the first
+ *   failure short-circuits and its error is returned immediately.
+ * @returns `Ok(value)` when all validators pass; `Err(E)` from the first
+ *   failing validator.
  *
  * @example
  * const isPositive: Validator<number> = (x) =>
@@ -538,7 +543,12 @@ export const validateAll =
   };
 
 /**
- * Combines multiple validators - at least one must pass
+ * Combines multiple validators — at least one must pass.
+ *
+ * @param validators - Array of validator functions. Checked in order; the first
+ *   success short-circuits and `Ok(value)` is returned.
+ * @returns `Ok(value)` when any validator passes; `Err(E[])` collecting every
+ *   error when all validators fail (last error is the last validator's error).
  *
  * @example
  * const isZero: Validator<number> = (x) =>
@@ -550,7 +560,7 @@ export const validateAll =
  * const validate = validateAny([isZero, isPositive]);
  * validate(5); // Ok(5)
  * validate(0); // Ok(0)
- * validate(-1); // Err('Not positive')
+ * validate(-1); // Err(['Not zero', 'Not positive'])
  */
 export const validateAny =
   <T, E>(validators: Array<Validator<T, E>>) =>


### PR DESCRIPTION
## Summary

Adds missing `@param` and `@returns` tags to the most impactful multi-parameter functions identified in issue #89:

| Function | Added |
|---|---|
| `retry(maxAttempts, delayMs, backoff)` | All 3 `@param` + `@returns` |
| `chunk(size)` | `@param` size constraint + `@returns` last-chunk note |
| `truncate(maxLength, suffix)` | Both `@param` + `@returns` condition |
| `memoize(fn, keyFn)` | Both `@param` + `@returns` |
| `setPath(path, value)` | Both `@param` + `@returns` |
| `validateAll(validators)` | `@param` + `@returns` with fail-fast semantics |
| `validateAny(validators)` | `@param` + `@returns` with error-collection semantics; fix example output |

## Test plan

- [x] All 434 tests pass — docs-only change
- [x] ESLint + tsc clean

Closes #89