### PR TITLE
feat(composition,async): add maxSize to memoize/memoizeAsync for bounded caches

### DIFF
--- a/src/_internal/async-control.ts
+++ b/src/_internal/async-control.ts
@@ -150,15 +150,26 @@ export const throttleAsync =
  * Memoizes an async function. Returns `Result<T, Error>` — never rethrows.
  * Cached results are returned on subsequent calls with the same arguments.
  *
+ * @param fn - The async function to memoize.
+ * @param keyFn - Produces the cache key from the arguments (default: `JSON.stringify(args)`).
+ *   The default key function only works correctly for JSON-serialisable arguments.
+ * @param maxSize - Maximum number of entries to keep. When exceeded the oldest entry is evicted
+ *   (insertion-order FIFO). Defaults to unbounded.
+ * @returns An async wrapper returning `Ok(value)` on hit/success or `Err(error)` on failure.
+ *
  * @example
  * const fetchUser = memoizeAsync(async (id: string) => api.getUser(id));
  *
  * const r1 = await fetchUser('123'); // network call -> Ok(user)
  * const r2 = await fetchUser('123'); // cached       -> Ok(user)
+ *
+ * // With a size cap:
+ * const bounded = memoizeAsync(fetchUser, undefined, 500);
  */
 export const memoizeAsync = <T extends unknown[], R>(
   fn: (...args: T) => Promise<R>,
-  keyFn: (...args: T) => string = (...args) => JSON.stringify(args)
+  keyFn: (...args: T) => string = (...args) => JSON.stringify(args),
+  maxSize?: number
 ) => {
   const cache = new Map<string, R>();
 
@@ -171,6 +182,9 @@ export const memoizeAsync = <T extends unknown[], R>(
 
     try {
       const result = await fn(...args);
+      if (maxSize !== undefined && cache.size >= maxSize) {
+        cache.delete(cache.keys().next().value as string);
+      }
       cache.set(key, result);
       return Ok(result);
     } catch (err) {

--- a/src/_internal/fn-utils.ts
+++ b/src/_internal/fn-utils.ts
@@ -112,6 +112,10 @@ export const tap =
  * @param fn - The function whose results should be cached. Should be pure (same args → same result).
  * @param keyFn - Produces the cache key from the arguments (default: `JSON.stringify(args)`).
  *   Use a custom `keyFn` when args contain non-serialisable values (e.g. objects by reference).
+ *   The default key function only works correctly for JSON-serialisable arguments; it will throw
+ *   on circular references and silently produce wrong keys for `undefined`, functions, `Map`, `Set`.
+ * @param maxSize - Maximum number of entries to keep. When exceeded the oldest entry is evicted
+ *   (insertion-order FIFO). Defaults to unbounded.
  * @returns A memoized wrapper that returns cached results on repeated calls with equal keys.
  *
  * @example
@@ -119,10 +123,14 @@ export const tap =
  * const fastFn = memoize(slowFn);
  * fastFn(5); // computed
  * fastFn(5); // cached
+ *
+ * // With a size cap:
+ * const bounded = memoize(slowFn, undefined, 100);
  */
 export const memoize = <T extends unknown[], R>(
   fn: (...args: T) => R,
-  keyFn: (...args: T) => string = (...args) => JSON.stringify(args)
+  keyFn: (...args: T) => string = (...args) => JSON.stringify(args),
+  maxSize?: number
 ): ((...args: T) => R) => {
   const cache = new Map<string, R>();
 
@@ -134,6 +142,9 @@ export const memoize = <T extends unknown[], R>(
     }
 
     const result = fn(...args);
+    if (maxSize !== undefined && cache.size >= maxSize) {
+      cache.delete(cache.keys().next().value as string);
+    }
     cache.set(key, result);
     return result;
   };

--- a/tests/async.test.ts
+++ b/tests/async.test.ts
@@ -136,6 +136,23 @@ describe('memoizeAsync', () => {
     const r = await fn('bad json');
     expect(isErr(r)).toBe(true);
   });
+
+  it('evicts oldest entry when maxSize is exceeded', async () => {
+    let calls = 0;
+    const fn = memoizeAsync(async (n: number) => { calls++; return n * 2; }, undefined, 2);
+
+    await fn(1); // cache: {1}
+    await fn(2); // cache: {1, 2}
+    await fn(3); // evict 1, cache: {2, 3}
+    expect(calls).toBe(3);
+
+    await fn(2); // hit
+    await fn(3); // hit
+    expect(calls).toBe(3);
+
+    await fn(1); // miss — re-computed
+    expect(calls).toBe(4);
+  });
 });
 
 describe('sequence', () => {

--- a/tests/composition.test.ts
+++ b/tests/composition.test.ts
@@ -140,6 +140,23 @@ describe('memoize', () => {
     expensive(10);
     expect(calls).toBe(2);
   });
+
+  it('evicts oldest entry when maxSize is exceeded', () => {
+    let calls = 0;
+    const fn = memoize((n: number) => { calls++; return n * 2; }, undefined, 2);
+
+    fn(1); // cache: {1}
+    fn(2); // cache: {1, 2}
+    fn(3); // cache full → evict 1, cache: {2, 3}
+    expect(calls).toBe(3);
+
+    fn(2); // hit
+    fn(3); // hit
+    expect(calls).toBe(3);
+
+    fn(1); // miss (was evicted) → re-computed
+    expect(calls).toBe(4);
+  });
 });
 
 describe('flip', () => {


### PR DESCRIPTION
## Summary

Both `memoize` and `memoizeAsync` used an unbounded `Map` that could grow indefinitely in long-running applications.

Added an optional `maxSize` parameter (third positional arg). When the cache reaches capacity before adding a new entry, the oldest entry is evicted (insertion-order FIFO — `Map` preserves insertion order in JS).

Also documented the default `keyFn` limitation: `JSON.stringify` only works for JSON-serialisable arguments — circular refs throw, `undefined`/functions/`Map`/`Set` produce incorrect keys.

```ts
// Unbounded (default behaviour unchanged)
const cached = memoize(fn);

// Bounded — keeps at most 100 entries
const bounded = memoize(fn, undefined, 100);
```

## Test plan

- [x] All 436 tests pass (2 new tests added)
- [x] ESLint + tsc clean
- [x] Non-breaking: existing calls without `maxSize` are unaffected

Closes #87