### PR TITLE
feat(result): add validateCollect — run all validators and collect every error

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -577,3 +577,40 @@ export const validateAny =
 
     return Err(errors);
   };
+
+/**
+ * Runs all validators and collects every failure (error accumulation).
+ * Unlike `validateAll` (fail-fast), all validators are always executed so
+ * every error is reported at once — useful for form validation.
+ *
+ * @param validators - Array of validator functions. All are executed regardless
+ *   of earlier failures.
+ * @returns `Ok(value)` when all validators pass; `Err(E[])` containing every
+ *   error from every failing validator, in order.
+ *
+ * @example
+ * const isPositive: Validator<number> = (x) =>
+ *   x > 0 ? Ok(x) : Err('Must be positive');
+ *
+ * const isEven: Validator<number> = (x) =>
+ *   x % 2 === 0 ? Ok(x) : Err('Must be even');
+ *
+ * const validate = validateCollect([isPositive, isEven]);
+ * validate(4);  // Ok(4)
+ * validate(3);  // Err(['Must be even'])
+ * validate(-3); // Err(['Must be positive', 'Must be even'])
+ */
+export const validateCollect =
+  <T, E>(validators: Array<Validator<T, E>>) =>
+  (value: T): Result<T, E[]> => {
+    const errors: E[] = [];
+
+    for (const validator of validators) {
+      const result = validator(value);
+      if (isErr(result)) {
+        errors.push(result.error);
+      }
+    }
+
+    return errors.length === 0 ? Ok(value) : Err(errors);
+  };

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -9,7 +9,7 @@ import {
   combineAll, combineTwo, collectErrors,
   tryCatch, tryCatchAsync,
   fromPromise,
-  validateAll, validateAny,
+  validateAll, validateAny, validateCollect,
   mapResultAsync, flatMapAsync,
   tapResult, tapError, orElse, fromNullableResult,
   bimap, mapLeft, swap, toOption,
@@ -202,6 +202,22 @@ describe('Result — validation', () => {
 
   it('validateAny fails if all validators fail', () => {
     expect(isErr(validateAny([isPositive, isEven])(-3))).toBe(true);
+  });
+
+  it('validateCollect returns Ok when all pass', () => {
+    expect(isOk(validateCollect([isPositive, isEven])(4))).toBe(true);
+  });
+
+  it('validateCollect collects all errors without short-circuiting', () => {
+    const r = validateCollect([isPositive, isEven])(-3);
+    expect(isErr(r)).toBe(true);
+    if (!r.ok) expect(r.error).toEqual(['not positive', 'not even']);
+  });
+
+  it('validateCollect collects only failing validators', () => {
+    const r = validateCollect([isPositive, isEven])(3);
+    expect(isErr(r)).toBe(true);
+    if (!r.ok) expect(r.error).toEqual(['not even']);
   });
 });
 


### PR DESCRIPTION
## Summary

`validateAll` is fail-fast (stops at first error), which is correct for short-circuit checks but unsuitable for form validation where all errors should be shown at once.

`validateCollect` runs every validator regardless of earlier failures and returns:
- `Ok(value)` when all validators pass
- `Err(E[])` containing every error from every failing validator, in order

```ts
const validate = validateCollect([isPositive, isEven]);
validate(4);  // Ok(4)
validate(3);  // Err(['not even'])
validate(-3); // Err(['not positive', 'not even'])  ← all errors collected
```

This complements the existing `validateAll` (fail-fast) and `validateAny` (first-pass) trio.

## Test plan

- [x] All 439 tests pass (3 new tests added)
- [x] ESLint + tsc clean
- [x] Exported from `src/result.ts` (picked up by `export * from './result.js'` in index)

Closes #86