### PR TITLE
refactor(composition,async): extend compose/pipeAsync overloads from 6 to 10 steps

### DIFF
--- a/src/_internal/async-composition.ts
+++ b/src/_internal/async-composition.ts
@@ -48,6 +48,48 @@ export function pipeAsync<A, B, C, D, E, F, G>(
   fn5: (e: E) => Promise<F>,
   fn6: (f: F) => Promise<G>
 ): (a: A) => Promise<G>;
+export function pipeAsync<A, B, C, D, E, F, G, H>(
+  fn1: (a: A) => Promise<B>,
+  fn2: (b: B) => Promise<C>,
+  fn3: (c: C) => Promise<D>,
+  fn4: (d: D) => Promise<E>,
+  fn5: (e: E) => Promise<F>,
+  fn6: (f: F) => Promise<G>,
+  fn7: (g: G) => Promise<H>
+): (a: A) => Promise<H>;
+export function pipeAsync<A, B, C, D, E, F, G, H, I>(
+  fn1: (a: A) => Promise<B>,
+  fn2: (b: B) => Promise<C>,
+  fn3: (c: C) => Promise<D>,
+  fn4: (d: D) => Promise<E>,
+  fn5: (e: E) => Promise<F>,
+  fn6: (f: F) => Promise<G>,
+  fn7: (g: G) => Promise<H>,
+  fn8: (h: H) => Promise<I>
+): (a: A) => Promise<I>;
+export function pipeAsync<A, B, C, D, E, F, G, H, I, J>(
+  fn1: (a: A) => Promise<B>,
+  fn2: (b: B) => Promise<C>,
+  fn3: (c: C) => Promise<D>,
+  fn4: (d: D) => Promise<E>,
+  fn5: (e: E) => Promise<F>,
+  fn6: (f: F) => Promise<G>,
+  fn7: (g: G) => Promise<H>,
+  fn8: (h: H) => Promise<I>,
+  fn9: (i: I) => Promise<J>
+): (a: A) => Promise<J>;
+export function pipeAsync<A, B, C, D, E, F, G, H, I, J, K>(
+  fn1: (a: A) => Promise<B>,
+  fn2: (b: B) => Promise<C>,
+  fn3: (c: C) => Promise<D>,
+  fn4: (d: D) => Promise<E>,
+  fn5: (e: E) => Promise<F>,
+  fn6: (f: F) => Promise<G>,
+  fn7: (g: G) => Promise<H>,
+  fn8: (h: H) => Promise<I>,
+  fn9: (i: I) => Promise<J>,
+  fn10: (j: J) => Promise<K>
+): (a: A) => Promise<K>;
 export function pipeAsync(
   ...fns: Array<(arg: unknown) => Promise<unknown>>
 ): (value: unknown) => Promise<unknown> {

--- a/src/_internal/compose.ts
+++ b/src/_internal/compose.ts
@@ -31,6 +31,18 @@ export function compose<A, B, C, D, E, F>(
 export function compose<A, B, C, D, E, F, G>(
   f6: (f: F) => G, f5: (e: E) => F, f4: (d: D) => E,
   f3: (c: C) => D, f2: (b: B) => C, f1: (a: A) => B): (a: A) => G;
+export function compose<A, B, C, D, E, F, G, H>(
+  f7: (g: G) => H, f6: (f: F) => G, f5: (e: E) => F, f4: (d: D) => E,
+  f3: (c: C) => D, f2: (b: B) => C, f1: (a: A) => B): (a: A) => H;
+export function compose<A, B, C, D, E, F, G, H, I>(
+  f8: (h: H) => I, f7: (g: G) => H, f6: (f: F) => G, f5: (e: E) => F, f4: (d: D) => E,
+  f3: (c: C) => D, f2: (b: B) => C, f1: (a: A) => B): (a: A) => I;
+export function compose<A, B, C, D, E, F, G, H, I, J>(
+  f9: (i: I) => J, f8: (h: H) => I, f7: (g: G) => H, f6: (f: F) => G, f5: (e: E) => F,
+  f4: (d: D) => E, f3: (c: C) => D, f2: (b: B) => C, f1: (a: A) => B): (a: A) => J;
+export function compose<A, B, C, D, E, F, G, H, I, J, K>(
+  f10: (j: J) => K, f9: (i: I) => J, f8: (h: H) => I, f7: (g: G) => H, f6: (f: F) => G,
+  f5: (e: E) => F, f4: (d: D) => E, f3: (c: C) => D, f2: (b: B) => C, f1: (a: A) => B): (a: A) => K;
 export function compose(...fns: Array<(x: unknown) => unknown>): (a: unknown) => unknown {
   return (value: unknown) => fns.reduceRight((acc, fn) => fn(acc), value);
 }


### PR DESCRIPTION
## Summary

`compose` and `pipeAsync` were limited to 6-step type-safe pipelines while `pipe` and `flow` supported 10. This meant users with 7–10 step pipelines had to split chains when using these functions.

Extended both to 10 overloads to match `pipe`/`flow`. No logic changes — only additional TypeScript overload signatures.

| Function | Before | After |
|---|---|---|
| `pipe` | 10 | 10 (unchanged) |
| `flow` | 10 | 10 (unchanged) |
| `compose` | **6** | **10** |
| `pipeAsync` | **6** | **10** |

## Test plan

- [x] All 439 tests pass — no logic changes
- [x] ESLint + tsc clean

Closes #84