### PR TITLE
refactor(array): find returns Option<T> instead of T | undefined

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -108,16 +108,20 @@ export const skip =
     arr.slice(n);
 
 /**
- * Returns the first element that satisfies a predicate (curried, data-last).
+ * Returns the first element that satisfies a predicate wrapped in `Some`,
+ * or `None` if no element matches (curried, data-last).
  *
  * @example
  * const isEven = (x: number) => x % 2 === 0;
- * find(isEven)([1, 3, 4, 5]); // 4
+ * find(isEven)([1, 3, 4, 5]); // Some(4)
+ * find(isEven)([1, 3, 5]);     // None
  */
 export const find =
   <T>(predicate: (item: T) => boolean) =>
-  (arr: T[]): T | undefined =>
-    arr.find(predicate);
+  (arr: T[]): Option<T> => {
+    const result = arr.find(predicate);
+    return result !== undefined ? Some(result) : None;
+  };
 
 /**
  * Returns true if at least one element satisfies the predicate (curried, data-last).

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -8,7 +8,7 @@ import {
   compact, hasItems,
   head, tail, last, init, nth,
 } from '../src/array.js';
-import { Some, None } from '../src/option.js';
+import { Some, None, isSome, isNone } from '../src/option.js';
 
 describe('map', () => {
   it('transforms every element', () => {
@@ -102,12 +102,14 @@ describe('skip', () => {
 });
 
 describe('find', () => {
-  it('returns the first matching element', () => {
-    expect(find((x: number) => x % 2 === 0)([1, 3, 4, 6])).toBe(4);
+  it('returns Some with the first matching element', () => {
+    const result = find((x: number) => x % 2 === 0)([1, 3, 4, 6]);
+    expect(isSome(result)).toBe(true);
+    if (isSome(result)) expect(result.value).toBe(4);
   });
 
-  it('returns undefined when nothing matches', () => {
-    expect(find((x: number) => x > 10)([1, 2, 3])).toBeUndefined();
+  it('returns None when nothing matches', () => {
+    expect(isNone(find((x: number) => x > 10)([1, 2, 3]))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

`find` was the only array function that could return nothing but used `T | undefined` instead of `Option<T>`, inconsistent with `head`, `last`, `tail`, `nth`, and `init`.

This eliminates the explicit `fromNullable` step needed when chaining `find` into a `pipe` alongside `mapOption`/`flatMapOption`:

```ts
// Before
pipe(users, find(isActive), fromNullable, mapOption(getName));

// After
pipe(users, find(isActive), mapOption(getName));
```

## Breaking change

Callers checking `=== undefined` must switch to `isNone`/`isSome` or `unwrapOptionOr`.

## Test plan

- [x] All 439 tests pass
- [x] ESLint + tsc clean

Closes #82