### PR TITLE
refactor(async): add flowAsync alias for pipeAsync; clarify point-free naming

### DIFF
--- a/src/_internal/async-composition.ts
+++ b/src/_internal/async-composition.ts
@@ -8,14 +8,24 @@
 // ============================================================================
 
 /**
- * Async version of `pipe` — composes async functions left to right.
+ * Composes async functions left-to-right, returning a **new function** (point-free).
+ * This is the async equivalent of `flow`, not `pipe` — it does not accept a value
+ * directly; instead it returns a function that you call with the initial value.
+ *
+ * Use `flowAsync` as a self-documenting alias if you prefer the `flow` naming:
  *
  * @example
  * const fetchUser = async (id: string) => ({ id, name: 'Alice' });
  * const getEmail = async (user: { email: string }) => user.email;
  * const sendEmail = async (email: string) => console.log(`Sent to ${email}`);
  *
- * await pipeAsync(fetchUser, getEmail, sendEmail)('user-123');
+ * // pipeAsync — point-free (returns a function)
+ * const process = pipeAsync(fetchUser, getEmail, sendEmail);
+ * await process('user-123');
+ *
+ * // flowAsync — identical behaviour, explicit name
+ * const process2 = flowAsync(fetchUser, getEmail, sendEmail);
+ * await process2('user-123');
  */
 export function pipeAsync<A, B>(fn1: (a: A) => Promise<B>): (a: A) => Promise<B>;
 export function pipeAsync<A, B, C>(
@@ -101,6 +111,17 @@ export function pipeAsync(
     return result;
   };
 }
+
+/**
+ * Self-documenting alias for {@link pipeAsync}.
+ * Use when you want to make it clear you are building a point-free async pipeline,
+ * mirroring the sync `flow` / `pipe` naming convention.
+ *
+ * @example
+ * const process = flowAsync(fetchUser, enrichUser, formatUser);
+ * await process('user-123');
+ */
+export const flowAsync = pipeAsync;
 
 /**
  * Async version of `compose` — composes async functions right to left.

--- a/src/async.ts
+++ b/src/async.ts
@@ -5,6 +5,7 @@
 
 export {
   pipeAsync,
+  flowAsync,
   composeAsync,
 } from './_internal/async-composition.js';
 

--- a/tests/async.test.ts
+++ b/tests/async.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   pipeAsync,
+  flowAsync,
   composeAsync,
   mapAsync, mapParallel, mapConcurrent,
   filterAsync, reduceAsync,
@@ -272,6 +273,15 @@ describe('throttleAsync', () => {
     expect(r1).toBe(6);
     expect(r2).toBe(10);
     expect(inner).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('flowAsync', () => {
+  it('is an alias for pipeAsync — composes left to right', async () => {
+    const add1 = async (n: number) => n + 1;
+    const double = async (n: number) => n * 2;
+    const process = flowAsync(add1 as (n: unknown) => Promise<unknown>, double as (n: unknown) => Promise<unknown>);
+    expect(await process(5)).toBe(12); // double(add1(5)) = double(6) = 12
   });
 });
 


### PR DESCRIPTION
Closes #83

## Summary

- Add `flowAsync` as a self-documenting alias for `pipeAsync` (non-breaking)
- Update `pipeAsync` JSDoc to clearly explain the point-free convention (returns a function, does not accept a value directly)
- Export `flowAsync` from `src/async.ts`
- Add test verifying `flowAsync` composes left-to-right identically to `pipeAsync`

## Approach

The issue noted that `pipeAsync` behaves like `flow` (point-free) while `pipe` (sync) accepts a value directly. Rather than a breaking rename, we add `flowAsync` as an explicit alias so both names work — existing code is unaffected, new code can use the self-documenting name.