### PR TITLE
refactor(result/option): extract interop to break circular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     "./composition": {
       "types": "./dist/composition.d.ts",
       "import": "./dist/composition.js"
+    },
+    "./interop": {
+      "types": "./dist/interop.d.ts",
+      "import": "./dist/interop.js"
     }
   },
   "sideEffects": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ export * from './result.js';
 // Option<T> — explicit nullability, no null checks
 export * from './option.js';
 
+// Interop — toOption, optionToResult, resultToOption (bridges Result ↔ Option)
+export * from './interop.js';
+
 // pipe / compose / curry — type-safe composition (10+ steps inferred)
 export * from './composition.js';
 

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -1,0 +1,42 @@
+/**
+ * Interop utilities between Option<T> and Result<T, E>.
+ * Extracted here to break the circular dependency between result.ts and option.ts.
+ * @module interop
+ */
+
+import type { Option } from './option.js';
+import { Some, None, isSome } from './option.js';
+import type { Result } from './result.js';
+import { Ok, Err, isOk } from './result.js';
+
+/**
+ * Convert a Result to an Option, discarding the error on Err.
+ *
+ * @example
+ * toOption(Ok(42));      // Some(42)
+ * toOption(Err('oops')); // None
+ */
+export const toOption = <T, E>(result: Result<T, E>): Option<T> =>
+  isOk(result) ? Some(result.value) : None;
+
+/**
+ * Converts Result<T, E> to Option<T>, discarding the error.
+ * Alias for {@link toOption}.
+ *
+ * @example
+ * resultToOption(Ok(42))      // Some(42)
+ * resultToOption(Err('oops')) // None
+ */
+export const resultToOption = toOption;
+
+/**
+ * Converts Option<T> to Result<T, E>.
+ *
+ * @example
+ * optionToResult(() => 'not found')(Some(42))  // Ok(42)
+ * optionToResult(() => 'not found')(None)       // Err('not found')
+ */
+export const optionToResult =
+  <T, E>(onNone: () => E) =>
+  (opt: Option<T>): Result<T, E> =>
+    isSome(opt) ? Ok(opt.value) : Err(onNone());

--- a/src/option.ts
+++ b/src/option.ts
@@ -168,31 +168,3 @@ export const compactOptions = <T>(opts: Array<Option<T>>): T[] => {
   return result;
 };
 
-// ============================================================================
-// INTEROP WITH RESULT
-// ============================================================================
-
-import type { Result } from './result.js';
-import { Ok, Err } from './result.js';
-
-/**
- * Converts Option<T> to Result<T, E>.
- *
- * @example
- * optionToResult(() => 'not found')(Some(42))  // Ok(42)
- * optionToResult(() => 'not found')(None)       // Err('not found')
- */
-export const optionToResult =
-  <T, E>(onNone: () => E) =>
-  (opt: Option<T>): Result<T, E> =>
-    isSome(opt) ? Ok(opt.value) : Err(onNone());
-
-/**
- * Converts Result<T, E> to Option<T>, discarding the error.
- *
- * @example
- * resultToOption(Ok(42))         // Some(42)
- * resultToOption(Err('oops'))    // None
- */
-export const resultToOption = <T, E>(result: Result<T, E>): Option<T> =>
-  result.ok ? Some(result.value) : None;

--- a/src/result.ts
+++ b/src/result.ts
@@ -4,9 +4,6 @@
  * @module result
  */
 
-import type { Option } from './option.js';
-import { Some, None } from './option.js';
-
 // ============================================================================
 // RESULT TYPE
 // ============================================================================
@@ -395,7 +392,7 @@ export const tryCatch =
   };
 
 // ============================================================================
-// OPTION INTEROP
+// BIMAP / MAPBOTH
 // ============================================================================
 
 /**
@@ -430,16 +427,6 @@ export const mapLeft = mapErr;
  */
 export const swap = <T, E>(result: Result<T, E>): Result<E, T> =>
   isOk(result) ? Err(result.value) : Ok(result.error);
-
-/**
- * Convert a Result to an Option, discarding the error on Err.
- *
- * @example
- * toOption(Ok(42));      // Some(42)
- * toOption(Err('oops')); // None
- */
-export const toOption = <T, E>(result: Result<T, E>): Option<T> =>
-  isOk(result) ? Some(result.value) : None;
 
 /**
  * Async version of tryCatch

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -9,9 +9,9 @@ import {
   orElseOption,
   toNullable, toArray,
   zipOption, sequenceOption, compactOptions,
-  optionToResult, resultToOption,
 } from '../src/option.js';
 import { Ok, Err, isOk, isErr } from '../src/result.js';
+import { optionToResult, resultToOption } from '../src/interop.js';
 
 describe('Option — constructors', () => {
   it('Some wraps a value', () => {

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -12,11 +12,12 @@ import {
   validateAll, validateAny, validateCollect,
   mapResultAsync, flatMapAsync,
   tapResult, tapError, orElse, fromNullableResult,
-  bimap, mapLeft, swap, toOption,
+  bimap, mapLeft, swap,
   ap, liftA2, liftA3,
   type Result,
 } from '../src/result.js';
 import { Some, None } from '../src/option.js';
+import { toOption } from '../src/interop.js';
 
 describe('Result — constructors', () => {
   it('Ok creates a success', () => {


### PR DESCRIPTION
Closes #85

## Summary

- Extract `toOption`, `resultToOption`, and `optionToResult` from `result.ts` and `option.ts` into a new `src/interop.ts` module
- `result.ts` and `option.ts` no longer import each other — dependency graph is now a DAG
- Public API is unchanged: `index.ts` re-exports `interop.ts`, so `import { toOption } from '@roxdavirox/fp-core'` still works
- Added `./interop` subpath export to `package.json` for users who want to import interop functions independently
- Updated tests to import from `'../src/interop.js'` instead of the now-cleaner source modules

## Dependency graph before / after

```
Before (cycle):
  result.ts ──imports──▶ option.ts
  option.ts ──imports──▶ result.ts  ← cycle

After (DAG):
  result.ts            (no cross-dependency)
  option.ts            (no cross-dependency)
  interop.ts ──imports──▶ result.ts
  interop.ts ──imports──▶ option.ts
  index.ts   ──exports──▶ result, option, interop, ...
```