### PR TITLE
feat(alchemy): v0.3.0 — expert-level upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -203,4 +203,4 @@ Until `1.0.0`, minor releases may include breaking changes if they are clearly d
 
 ## License
 
-MIT © [roxdavirox](https://github.com/roxdavirox)
+MIT © [tecnomancy](https://github.com/tecnomancy)

--- a/benchmarks/array.bench.ts
+++ b/benchmarks/array.bench.ts
@@ -13,7 +13,7 @@ const isEven = (x: number) => x % 2 === 0;
 // ============================================================================
 
 describe('array.map — 1 000 numbers', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     map(double)(NUMBERS);
   });
 
@@ -39,7 +39,7 @@ describe('array.map — 1 000 numbers', () => {
 // ============================================================================
 
 describe('array.filter — 1 000 numbers', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     filter(isEven)(NUMBERS);
   });
 
@@ -68,7 +68,7 @@ const WORDS = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', '
 const byLength = (s: string) => String(s.length);
 
 describe('array.groupBy — 10 words', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     groupBy(byLength)(WORDS);
   });
 
@@ -90,7 +90,7 @@ describe('array.groupBy — 10 words', () => {
 // ============================================================================
 
 describe('array.chunk — 1 000 numbers, size 10', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     chunk(10)(NUMBERS);
   });
 

--- a/benchmarks/composition.bench.ts
+++ b/benchmarks/composition.bench.ts
@@ -15,7 +15,7 @@ const negate = (x: number) => -x;
 // ============================================================================
 
 describe('composition.pipe — 5 steps, number', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     pipe(10, add1, double, sub3, square, negate);
   });
 
@@ -37,7 +37,7 @@ describe('composition.pipe — 5 steps, number', () => {
 // ============================================================================
 
 describe('composition.compose — 5 steps, number', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     compose(negate, square, sub3, double, add1)(10);
   });
 

--- a/benchmarks/object.bench.ts
+++ b/benchmarks/object.bench.ts
@@ -12,7 +12,7 @@ interface FiveKey { a: number; b: number; c: number; d: number; e: number }
 const OBJ: FiveKey = { a: 1, b: 2, c: 3, d: 4, e: 5 };
 
 describe('object.pick — 5-key object, pick 2', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     pick<FiveKey, 'a' | 'b'>(['a', 'b'])(OBJ);
   });
 
@@ -34,7 +34,7 @@ describe('object.pick — 5-key object, pick 2', () => {
 // ============================================================================
 
 describe('object.omit — 5-key object, omit 2', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     omit<FiveKey, 'd' | 'e'>(['d', 'e'])(OBJ);
   });
 
@@ -59,7 +59,7 @@ const BASE = { a: 1, b: 2 };
 const PATCH = { b: 99, c: 3 };
 
 describe('object.merge — shallow merge', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     merge(BASE)(PATCH);
   });
 
@@ -88,7 +88,7 @@ interface Nested { user: { profile: { name: string; age: number } } }
 const NESTED: Nested = { user: { profile: { name: 'Alice', age: 30 } } };
 
 describe('object.getPath — 3-level deep access', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     getPath<Nested>(['user', 'profile', 'name'])(NESTED);
   });
 

--- a/benchmarks/result.bench.ts
+++ b/benchmarks/result.bench.ts
@@ -2,7 +2,7 @@ import { bench, describe } from 'vitest';
 import { Ok, Err, flatMap, match, combineAll, type Result } from '../src/result.js';
 
 // Competitors (Ramda, lodash, Remeda) have no Result/Either type.
-// The baseline is idiomatic try/catch to show fp-core's overhead vs. raw JS.
+// The baseline is idiomatic try/catch to show alchemy's overhead vs. raw JS.
 
 // ============================================================================
 // flatMap — chained safe computation
@@ -14,7 +14,7 @@ const safeDivide =
     x === 0 ? Err(new Error('division by zero')) : Ok(n / x);
 
 describe('result.flatMap — 3 chained operations', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     flatMap(safeDivide(6))(
       flatMap(safeDivide(100))(Ok<number, Error>(10))
     );
@@ -44,7 +44,7 @@ const matchFns: [(v: number) => string, (e: Error) => string] = [
 ];
 
 describe('result.match — ok branch', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     match(matchFns[0], matchFns[1])(okResult);
   });
 
@@ -56,7 +56,7 @@ describe('result.match — ok branch', () => {
 });
 
 describe('result.match — error branch', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     match(matchFns[0], matchFns[1])(errResult);
   });
 
@@ -79,7 +79,7 @@ const MIXED_RESULTS: Result<number, Error>[] = Array.from({ length: 100 }, (_, i
 );
 
 describe('result.combineAll — 100 Ok results', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     combineAll(OK_RESULTS);
   });
 
@@ -93,7 +93,7 @@ describe('result.combineAll — 100 Ok results', () => {
 });
 
 describe('result.combineAll — 100 results, 1 error at index 50', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     combineAll(MIXED_RESULTS);
   });
 

--- a/benchmarks/string.bench.ts
+++ b/benchmarks/string.bench.ts
@@ -12,7 +12,7 @@ import { camelCase, truncate, format, template } from '../src/string.js';
 const SNAKE = 'hello_world_foo_bar';
 
 describe('string.camelCase', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     camelCase(SNAKE);
   });
 
@@ -28,7 +28,7 @@ describe('string.camelCase', () => {
 const LONG = 'The quick brown fox jumps over the lazy dog near the riverbank';
 
 describe('string.truncate — 30 chars', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     truncate(30)(LONG);
   });
 
@@ -44,7 +44,7 @@ describe('string.truncate — 30 chars', () => {
 const FMT = 'Hello %s, you are %d years old';
 
 describe('string.format — 2 printf placeholders', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     format(FMT)('Alice', 30);
   });
 
@@ -63,7 +63,7 @@ const TMPL = 'Hello {{name}}, you have {{count}} messages.';
 const VALS = { name: 'Alice', count: 5 };
 
 describe('string.template — 2 key interpolations', () => {
-  bench('fp-core', () => {
+  bench('alchemy', () => {
     template(VALS)(TMPL);
   });
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# fp-core API Reference
+# alchemy API Reference
 
 Complete reference for all exported functions, organized by module.
 
@@ -6,11 +6,11 @@ Complete reference for all exported functions, organized by module.
 
 ```typescript
 // Root barrel — everything
-import { pipe, Ok, Err, Some, None } from '@roxdavirox/fp-core';
+import { pipe, Ok, Err, Some, None } from '@tecnomancy/alchemy';
 
 // Subpath — one module
-import { Ok, Err, flatMap } from '@roxdavirox/fp-core/result';
-import { pipe, compose } from '@roxdavirox/fp-core/composition';
+import { Ok, Err, flatMap } from '@tecnomancy/alchemy/result';
+import { pipe, compose } from '@tecnomancy/alchemy/composition';
 ```
 
 ---
@@ -30,7 +30,7 @@ import { pipe, compose } from '@roxdavirox/fp-core/composition';
 
 ## Result\<T, E\>
 
-`import { ... } from '@roxdavirox/fp-core/result'`
+`import { ... } from '@tecnomancy/alchemy/result'`
 
 Represents a value that is either a success (`Ok`) or a failure (`Err`).
 Use `Result` instead of throwing exceptions for expected failure paths.
@@ -563,7 +563,7 @@ fromNullableResult('not found')(undefined); // Err('not found')
 
 ## Option\<T\>
 
-`import { ... } from '@roxdavirox/fp-core/option'`
+`import { ... } from '@tecnomancy/alchemy/option'`
 
 Represents a value that may or may not be present. Use `Option` to eliminate `null`/`undefined` from your domain types.
 
@@ -856,7 +856,7 @@ resultToOption(Err('oops')); // None
 
 ## Composition
 
-`import { ... } from '@roxdavirox/fp-core/composition'`
+`import { ... } from '@tecnomancy/alchemy/composition'`
 
 ### `pipe(value, ...fns)`
 
@@ -1106,7 +1106,7 @@ isOdd(3); // true
 
 ## Async
 
-`import { ... } from '@roxdavirox/fp-core/async'`
+`import { ... } from '@tecnomancy/alchemy/async'`
 
 ### `pipeAsync(...fns)(value)`
 
@@ -1343,7 +1343,7 @@ await parallel([
 
 **Example:**
 ```typescript
-import { mapConcurrentResult, mapAsyncResult, collectErrors } from '@roxdavirox/fp-core';
+import { mapConcurrentResult, mapAsyncResult, collectErrors } from '@tecnomancy/alchemy';
 
 // mapAsyncResult — sequential, collects all errors
 const results = await mapAsyncResult(
@@ -1362,7 +1362,7 @@ const results2 = await mapConcurrentResult(
 
 ## Array
 
-`import { ... } from '@roxdavirox/fp-core/array'`
+`import { ... } from '@tecnomancy/alchemy/array'`
 
 All array functions are curried and data-last — designed to compose inside `pipe`.
 
@@ -1414,7 +1414,7 @@ All array functions are curried and data-last — designed to compose inside `pi
 
 **Example:**
 ```typescript
-import { head, tail, last, nth } from '@roxdavirox/fp-core';
+import { head, tail, last, nth } from '@tecnomancy/alchemy';
 
 head([1, 2, 3]); // Some(1)
 head([]);        // None
@@ -1443,7 +1443,7 @@ const [evens, odds] = partition(n => n % 2 === 0)([1, 2, 3, 4]);
 
 ## Object
 
-`import { ... } from '@roxdavirox/fp-core/object'`
+`import { ... } from '@tecnomancy/alchemy/object'`
 
 ### Picking & Merging
 
@@ -1523,7 +1523,7 @@ getPath(['db', 'port'])(config); // 5432
 
 ## String
 
-`import { ... } from '@roxdavirox/fp-core/string'`
+`import { ... } from '@tecnomancy/alchemy/string'`
 
 ### Case Conversion
 
@@ -1621,7 +1621,7 @@ format('Hello %s, you are %d years old')('Alice', 30);
 
 ## Predicates
 
-`import { ... } from '@roxdavirox/fp-core/predicates'`
+`import { ... } from '@tecnomancy/alchemy/predicates'`
 
 ### Logical Combinators
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -8,7 +8,7 @@
 
 ## Coming from Ramda
 
-| Ramda | fp-core |
+| Ramda | alchemy |
 |-------|---------|
 | `R.pipe(f, g)(x)` | `pipe(x, f, g)` |
 | `R.compose(g, f)(x)` | `compose(g, f)(x)` |
@@ -31,14 +31,14 @@
 
 Key differences:
 - **Value-first pipe**: `pipe(value, f, g)` instead of `pipe(f, g)(value)`. TypeScript infers every step without losing types.
-- **No `Maybe`/`Either`**: fp-core uses `Option<T>` and `Result<T, E>` with explicit constructors.
-- **No lens/transducer**: fp-core is intentionally limited to everyday utilities.
+- **No `Maybe`/`Either`**: alchemy uses `Option<T>` and `Result<T, E>` with explicit constructors.
+- **No lens/transducer**: alchemy is intentionally limited to everyday utilities.
 
 ---
 
 ## Coming from fp-ts
 
-| fp-ts | fp-core |
+| fp-ts | alchemy |
 |-------|---------|
 | `pipe(x, TE.map(f))` | `pipe(x, mapResult(f))` |
 | `E.right(x)` / `E.left(e)` | `Ok(x)` / `Err(e)` |
@@ -57,15 +57,15 @@ Key differences:
 | `flow(f, g)` | `flow(f, g)` or `pipe(x, f, g)` |
 
 Key differences:
-- **No HKT encoding**: fp-core does not use higher-kinded type emulation. The API is simpler but less polymorphic.
+- **No HKT encoding**: alchemy does not use higher-kinded type emulation. The API is simpler but less polymorphic.
 - **No type class hierarchy**: there is no `Functor`, `Monad`, or `Applicative` abstraction — each type has its own named functions.
-- **`match` argument order**: fp-core uses `match(onOk, onErr)` (success first), while fp-ts uses `fold(onLeft, onRight)` (failure first).
+- **`match` argument order**: alchemy uses `match(onOk, onErr)` (success first), while fp-ts uses `fold(onLeft, onRight)` (failure first).
 
 ---
 
 ## Coming from lodash/fp
 
-| lodash/fp | fp-core |
+| lodash/fp | alchemy |
 |-----------|---------|
 | `_.map(fn)(arr)` | `map(fn)(arr)` |
 | `_.filter(pred)(arr)` | `filter(pred)(arr)` |
@@ -90,4 +90,4 @@ Key differences:
 Key differences:
 - **TypeScript-native**: every function is typed precisely; no `any` leakage from lodash's overloads.
 - **No `_` namespace or chaining**: compose pipelines with `pipe` instead.
-- **Result/Option built-in**: fp-core replaces try/catch and null-check patterns structurally.
+- **Result/Option built-in**: alchemy replaces try/catch and null-check patterns structurally.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -1,6 +1,6 @@
-# fp-core Recipes
+# alchemy Recipes
 
-Real-world patterns using fp-core primitives. Every snippet is valid TypeScript.
+Real-world patterns using alchemy primitives. Every snippet is valid TypeScript.
 
 ---
 
@@ -29,7 +29,7 @@ import {
   flatMapAsync,
   mapResultAsync,
   match,
-} from '@roxdavirox/fp-core';
+} from '@tecnomancy/alchemy';
 
 interface User {
   id: string;
@@ -76,8 +76,8 @@ const getEnrichedUser = async (id: string) => {
 **Use case:** Validate multiple fields, collect all errors at once instead of stopping at the first failure.
 
 ```typescript
-import { Ok, Err, validateAll, collectErrors, match } from '@roxdavirox/fp-core';
-import type { Result } from '@roxdavirox/fp-core';
+import { Ok, Err, validateAll, collectErrors, match } from '@tecnomancy/alchemy';
+import type { Result } from '@tecnomancy/alchemy';
 
 interface SignupForm {
   email: string;
@@ -121,9 +121,9 @@ const result = validateForm({ email: 'bad', password: 'short', age: 16 });
 **Use case:** Parse and validate a JSON config file without crashing on bad input.
 
 ```typescript
-import { tryCatch, flatMap, unwrapOrElse } from '@roxdavirox/fp-core';
-import { Ok, Err } from '@roxdavirox/fp-core';
-import type { Result } from '@roxdavirox/fp-core';
+import { tryCatch, flatMap, unwrapOrElse } from '@tecnomancy/alchemy';
+import { Ok, Err } from '@tecnomancy/alchemy';
+import type { Result } from '@tecnomancy/alchemy';
 
 interface AppConfig {
   apiUrl: string;
@@ -171,8 +171,8 @@ loadConfig('not json');
 **Use case:** Read a deeply nested value that may not exist at any level without optional chaining.
 
 ```typescript
-import { getPathOr, fromNullable, mapOption, unwrapOptionOr } from '@roxdavirox/fp-core';
-import { pipe } from '@roxdavirox/fp-core';
+import { getPathOr, fromNullable, mapOption, unwrapOptionOr } from '@tecnomancy/alchemy';
+import { pipe } from '@tecnomancy/alchemy';
 
 interface Address {
   street?: string;
@@ -229,9 +229,9 @@ formatCity('bob');   // 'Unknown city'
 **Use case:** Run multiple async operations concurrently and collect all failures instead of stopping at the first.
 
 ```typescript
-import { mapAsyncResult, collectErrors, match } from '@roxdavirox/fp-core';
-import { Ok, Err } from '@roxdavirox/fp-core';
-import type { Result } from '@roxdavirox/fp-core';
+import { mapAsyncResult, collectErrors, match } from '@tecnomancy/alchemy';
+import { Ok, Err } from '@tecnomancy/alchemy';
+import type { Result } from '@tecnomancy/alchemy';
 
 interface OrderItem {
   productId: string;
@@ -283,8 +283,8 @@ const validation = await validateOrder(order);
 **Use case:** Fetch from an unstable API with automatic retries and exponential backoff.
 
 ```typescript
-import { pipeAsync, retry, match } from '@roxdavirox/fp-core';
-import { fromPromise } from '@roxdavirox/fp-core';
+import { pipeAsync, retry, match } from '@tecnomancy/alchemy';
+import { fromPromise } from '@tecnomancy/alchemy';
 
 interface ApiResponse {
   data: unknown;
@@ -336,8 +336,8 @@ const processEndpoint = pipeAsync(
 **Use case:** Chain optional property accesses through a deeply nested object without intermediate null checks.
 
 ```typescript
-import { fromNullable, flatMapOption, mapOption, unwrapOptionOr } from '@roxdavirox/fp-core';
-import { pipe } from '@roxdavirox/fp-core';
+import { fromNullable, flatMapOption, mapOption, unwrapOptionOr } from '@tecnomancy/alchemy';
+import { pipe } from '@tecnomancy/alchemy';
 
 interface Coordinates {
   lat: number;
@@ -396,9 +396,9 @@ formatEventLocation({ name: 'Carol', upcomingEvent: { title: 'Webinar' } });
 **Use case:** Process a batch of items concurrently (bounded concurrency) and surface all failures.
 
 ```typescript
-import { mapConcurrentResult, collectErrors, match } from '@roxdavirox/fp-core';
-import { Ok, Err } from '@roxdavirox/fp-core';
-import type { Result } from '@roxdavirox/fp-core';
+import { mapConcurrentResult, collectErrors, match } from '@tecnomancy/alchemy';
+import { Ok, Err } from '@tecnomancy/alchemy';
+import type { Result } from '@tecnomancy/alchemy';
 
 interface Report {
   userId: string;
@@ -449,9 +449,9 @@ const generateAllReports = async (reports: Report[]) => {
 **Use case:** Transform raw API data through a series of pure functions using `pipe`, array utilities, and object utilities.
 
 ```typescript
-import { pipe } from '@roxdavirox/fp-core';
-import { map, filter, sortBy, groupBy } from '@roxdavirox/fp-core';
-import { pick, mapValues } from '@roxdavirox/fp-core';
+import { pipe } from '@tecnomancy/alchemy';
+import { map, filter, sortBy, groupBy } from '@tecnomancy/alchemy';
+import { pick, mapValues } from '@tecnomancy/alchemy';
 
 interface RawProduct {
   id: string;
@@ -502,9 +502,9 @@ const clientCatalog = pipe(
 **Use case:** Merge user-supplied config over defaults, then validate the result.
 
 ```typescript
-import { defaults, validateAll, match } from '@roxdavirox/fp-core';
-import { Ok, Err } from '@roxdavirox/fp-core';
-import type { Result } from '@roxdavirox/fp-core';
+import { defaults, validateAll, match } from '@tecnomancy/alchemy';
+import { Ok, Err } from '@tecnomancy/alchemy';
+import type { Result } from '@tecnomancy/alchemy';
 
 interface ServerConfig {
   host: string;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ export default tseslint.config(
       parserOptions: {
         projectService: {
           allowDefaultProject: ['tests/*.ts'],
+          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 16,
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tecnomancy/alchemy",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Functional programming primitives for TypeScript — every type inferred, zero dependencies.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/_internal/async-array.ts
+++ b/src/_internal/async-array.ts
@@ -151,7 +151,7 @@ export const mapConcurrentResult =
     for (const [index, item] of arr.entries()) {
       const p: Promise<void> = fn(item)
         .then(r => { settled[index] = r; })
-        .catch((e: unknown) => { settled[index] = Err(e as E); })
+        .catch((e: unknown) => { settled[index] = Err((e instanceof Error ? e : new Error(String(e))) as E); })
         .finally(() => { executing.delete(p); });
       executing.add(p);
       if (executing.size >= concurrency) await Promise.race(executing);

--- a/src/_internal/async-composition.ts
+++ b/src/_internal/async-composition.ts
@@ -3,6 +3,16 @@
  * @internal
  */
 
+// ── Internal helper (module-level, not re-created per call) ────────────────
+const runPipeline = async (
+  initial: unknown,
+  fns: Array<(arg: unknown) => Promise<unknown>>
+): Promise<unknown> => {
+  let result = initial;
+  for (const fn of fns) result = await fn(result);
+  return result;
+};
+
 // ============================================================================
 // ASYNC COMPOSITION
 // ============================================================================
@@ -127,15 +137,6 @@ export function pipeAsync<A, B, C, D, E, F, G, H, I, J, K>(
 ): (a: A) => Promise<K>;
 // ── Implementation ─────────────────────────────────────────────────────────
 export function pipeAsync(...args: unknown[]): unknown {
-  const runPipeline = async (
-    initial: unknown,
-    fns: Array<(arg: unknown) => Promise<unknown>>
-  ): Promise<unknown> => {
-    let result = initial;
-    for (const fn of fns) result = await fn(result);
-    return result;
-  };
-
   if (typeof args[0] !== 'function') {
     // Value-first: execute immediately, return Promise
     const [value, ...fns] = args as [unknown, ...Array<(arg: unknown) => Promise<unknown>>];

--- a/src/_internal/compose.ts
+++ b/src/_internal/compose.ts
@@ -44,7 +44,11 @@ export function compose<A, B, C, D, E, F, G, H, I, J, K>(
   f10: (j: J) => K, f9: (i: I) => J, f8: (h: H) => I, f7: (g: G) => H, f6: (f: F) => G,
   f5: (e: E) => F, f4: (d: D) => E, f3: (c: C) => D, f2: (b: B) => C, f1: (a: A) => B): (a: A) => K;
 export function compose(...fns: Array<(x: unknown) => unknown>): (a: unknown) => unknown {
-  return (value: unknown) => fns.reduceRight((acc, fn) => fn(acc), value);
+  return (value: unknown) => {
+    let result = value;
+    for (let i = fns.length - 1; i >= 0; i--) result = fns[i]!(result);
+    return result;
+  };
 }
 
 // ============================================================================
@@ -92,5 +96,9 @@ export function flow<A, B, C, D, E, F, G, H, I, J, K>(
   f4: (d: D) => E, f5: (e: E) => F, f6: (f: F) => G,
   f7: (g: G) => H, f8: (h: H) => I, f9: (i: I) => J, f10: (j: J) => K): (a: A) => K;
 export function flow(...fns: Array<(x: unknown) => unknown>): (a: unknown) => unknown {
-  return (value: unknown) => fns.reduce((acc, fn) => fn(acc), value);
+  return (value: unknown) => {
+    let result = value;
+    for (let i = 0; i < fns.length; i++) result = fns[i]!(result);
+    return result;
+  };
 }

--- a/src/_internal/pipe.ts
+++ b/src/_internal/pipe.ts
@@ -52,5 +52,7 @@ export function pipe<A, B, C, D, E, F, G, H, I, J, K>(
   f4: (d: D) => E, f5: (e: E) => F, f6: (f: F) => G, f7: (g: G) => H,
   f8: (h: H) => I, f9: (i: I) => J, f10: (j: J) => K): K;
 export function pipe(value: unknown, ...fns: Array<(x: unknown) => unknown>): unknown {
-  return fns.reduce((acc, fn) => fn(acc), value);
+  let result = value;
+  for (let i = 0; i < fns.length; i++) result = fns[i]!(result);
+  return result;
 }

--- a/src/array.ts
+++ b/src/array.ts
@@ -303,7 +303,7 @@ export const chunk =
  * // [1, 2, 3]
  */
 export const compact = <T>(arr: Array<T | null | undefined | false | 0 | ''>): T[] =>
-  arr.filter(Boolean) as T[];
+  arr.filter((x): x is T => Boolean(x));
 
 /**
  * Returns true if the value is a non-empty array.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * fp-core — Functional Programming Primitives for TypeScript
+ * alchemy — Functional Programming Primitives for TypeScript
  *
  * Zero-dependency. Tree-shakeable. TypeScript-native.
  * Every function is pure, curried, and data-last.
  *
- * @module @roxdavirox/fp-core
+ * @module @tecnomancy/alchemy
  */
 
 // Result<T, E> — explicit error handling, no exceptions

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -21,11 +21,7 @@ export const toOption = <T, E>(result: Result<T, E>): Option<T> =>
 
 /**
  * Converts Result<T, E> to Option<T>, discarding the error.
- * Alias for {@link toOption}.
- *
- * @example
- * resultToOption(Ok(42))      // Some(42)
- * resultToOption(Err('oops')) // None
+ * @deprecated Use {@link toOption} instead.
  */
 export const resultToOption = toOption;
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -210,3 +210,46 @@ export const getOrElse = unwrapOptionOrElse;
  */
 export const getOr = unwrapOptionOr;
 
+// ============================================================================
+// ADDITIONAL COMBINATORS
+// ============================================================================
+
+/**
+ * Lifts a predicate into an Option. Returns Some if the predicate holds,
+ * otherwise None.
+ *
+ * @example
+ * const positive = fromPredicateOption((n: number) => n > 0);
+ * positive(5);  // Some(5)
+ * positive(-1); // None
+ */
+export const fromPredicateOption =
+  <T>(predicate: (value: T) => boolean) =>
+  (value: T): Option<T> =>
+    predicate(value) ? Some(value) : None;
+
+/**
+ * Maps each element through an Option-returning function and collects
+ * all Some values. Short-circuits on the first None.
+ *
+ * More efficient than `map(fn) |> sequenceOption` because it avoids
+ * building the intermediate Option array.
+ *
+ * @example
+ * const safeSqrt = (n: number): Option<number> =>
+ *   n >= 0 ? Some(Math.sqrt(n)) : None;
+ *
+ * traverseOption(safeSqrt)([4, 9, 16]); // Some([2, 3, 4])
+ * traverseOption(safeSqrt)([4, -1, 16]); // None
+ */
+export const traverseOption =
+  <T, R>(fn: (value: T) => Option<R>) =>
+  (arr: T[]): Option<R[]> => {
+    const values: R[] = [];
+    for (const item of arr) {
+      const result = fn(item);
+      if (isNone(result)) return None;
+      values.push(result.value);
+    }
+    return Some(values);
+  };

--- a/src/result.ts
+++ b/src/result.ts
@@ -9,9 +9,20 @@
 // ============================================================================
 
 /**
- * Result type - represents success (Ok) or failure (Err)
+ * Branded Ok variant — success branch of a Result.
  */
-export type Result<T, E = Error> = { ok: true; value: T } | { ok: false; error: E };
+export type Ok<T> = { readonly _tag: 'Ok'; readonly ok: true; readonly value: T };
+
+/**
+ * Branded Err variant — failure branch of a Result.
+ */
+export type Err<E> = { readonly _tag: 'Err'; readonly ok: false; readonly error: E };
+
+/**
+ * Result type — represents success (Ok) or failure (Err).
+ * Uses `_tag` discriminant for structural consistency with Option.
+ */
+export type Result<T, E = Error> = Ok<T> | Err<E>;
 
 // ============================================================================
 // CONSTRUCTORS
@@ -22,9 +33,10 @@ export type Result<T, E = Error> = { ok: true; value: T } | { ok: false; error: 
  *
  * @example
  * const result = Ok(42);
- * // { ok: true, value: 42 }
+ * // { _tag: 'Ok', ok: true, value: 42 }
  */
 export const Ok = <T, E = Error>(value: T): Result<T, E> => ({
+  _tag: 'Ok',
   ok: true,
   value,
 });
@@ -34,9 +46,10 @@ export const Ok = <T, E = Error>(value: T): Result<T, E> => ({
  *
  * @example
  * const result = Err(new Error('Failed'));
- * // { ok: false, error: Error(...) }
+ * // { _tag: 'Err', ok: false, error: Error(...) }
  */
 export const Err = <T, E = Error>(error: E): Result<T, E> => ({
+  _tag: 'Err',
   ok: false,
   error,
 });
@@ -48,14 +61,14 @@ export const Err = <T, E = Error>(error: E): Result<T, E> => ({
 /**
  * Checks if Result is Ok
  */
-export const isOk = <T, E>(result: Result<T, E>): result is { ok: true; value: T } =>
-  result.ok === true;
+export const isOk = <T, E>(result: Result<T, E>): result is Ok<T> =>
+  result._tag === 'Ok';
 
 /**
  * Checks if Result is Err
  */
-export const isErr = <T, E>(result: Result<T, E>): result is { ok: false; error: E } =>
-  result.ok === false;
+export const isErr = <T, E>(result: Result<T, E>): result is Err<E> =>
+  result._tag === 'Err';
 
 // ============================================================================
 // TRANSFORMATIONS
@@ -134,7 +147,7 @@ export const unwrap = <T, E>(result: Result<T, E>): T => {
 };
 
 /**
- * UnwrapOr - extrai valor ou retorna default
+ * Extracts the value if Ok, otherwise returns the provided default
  *
  * @example
  * unwrapOr(0)(Ok(42)); // 42
@@ -146,7 +159,7 @@ export const unwrapOr =
     isOk(result) ? result.value : defaultValue;
 
 /**
- * UnwrapOrElse - extrai valor ou computa default
+ * Extracts the value if Ok, otherwise computes a fallback from the error
  *
  * @example
  * const getDefault = (e: Error) => {
@@ -161,7 +174,7 @@ export const unwrapOrElse =
     isOk(result) ? result.value : fn(result.error);
 
 /**
- * Match - pattern matching sobre Result
+ * Pattern match on a Result — apply one of two functions depending on Ok/Err
  *
  * @example
  * const result = Ok(42);
@@ -244,21 +257,27 @@ export const fromNullableResult =
 // ============================================================================
 
 /**
- * Combines two Results - both must be Ok
+ * Lift a 2-argument function to operate on two `Result` values.
+ * Returns `Ok(fn(a, b))` if both are `Ok`, otherwise returns the first `Err`.
  *
  * @example
- * const r1 = Ok(5);
- * const r2 = Ok(10);
- * const combined = combineTwo((a, b) => a + b)(r1, r2);
- * // Ok(15)
+ * const add = (a: number, b: number) => a + b;
+ * liftA2(add)(Ok(3), Ok(4));    // Ok(7)
+ * liftA2(add)(Err('x'), Ok(4)); // Err('x')
+ * liftA2(add)(Ok(3), Err('y')); // Err('y')
  */
-export const combineTwo =
+export const liftA2 =
   <T1, T2, R, E>(fn: (v1: T1, v2: T2) => R) =>
   (r1: Result<T1, E>, r2: Result<T2, E>): Result<R, E> => {
     if (isErr(r1)) return r1;
     if (isErr(r2)) return r2;
     return Ok(fn(r1.value, r2.value));
   };
+
+/**
+ * @deprecated Use {@link liftA2} instead.
+ */
+export const combineTwo = liftA2;
 
 /**
  * Combines array of Results - all must be Ok
@@ -304,20 +323,6 @@ export const ap =
   };
 
 /**
- * Lift a 2-argument function to operate on two `Result` values.
- * Returns `Ok(fn(a, b))` if both are `Ok`, otherwise returns the first `Err`.
- *
- * Alias for {@link combineTwo}.
- *
- * @example
- * const add = (a: number, b: number) => a + b;
- * liftA2(add)(Ok(3), Ok(4));    // Ok(7)
- * liftA2(add)(Err('x'), Ok(4)); // Err('x')
- * liftA2(add)(Ok(3), Err('y')); // Err('y')
- */
-export const liftA2 = combineTwo;
-
-/**
  * Lift a 3-argument function to operate on three `Result` values.
  * Returns `Ok(fn(a, b, c))` if all are `Ok`, otherwise returns the first `Err`.
  *
@@ -342,8 +347,8 @@ export const liftA3 =
  * @example
  * const results = [Ok(1), Err('e1'), Ok(2), Err('e2')];
  * const combined = collectErrors(results);
- * // Err(['e1', 'e2']) se houver erros
- * // Ok([1, 2]) se todos Ok
+ * // Err(['e1', 'e2']) if there are errors
+ * // Ok([1, 2]) if all Ok
  */
 export const collectErrors = <T, E>(results: Array<Result<T, E>>): Result<T[], E[]> => {
   const values: T[] = [];
@@ -364,44 +369,75 @@ export const collectErrors = <T, E>(results: Array<Result<T, E>>): Result<T[], E
 // ASYNC UTILITIES
 // ============================================================================
 
-/**
- * Converts a Promise to a Result
- *
- * @example
- * const result = await fromPromise(fetch('/api/data'));
- * // Ok(response) ou Err(error)
- */
-export const fromPromise = async <T, E = Error>(promise: Promise<T>): Promise<Result<T, E>> => {
-  try {
-    const value = await promise;
-    return Ok(value);
-  } catch (error) {
-    return Err((error instanceof Error ? error : new Error(String(error))) as unknown as E);
-  }
-};
+/** Normalizes an unknown thrown value into an Error. */
+const normalizeError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
 
 /**
- * Converts a throwing function into one that returns Result
+ * Converts a Promise to a Result.
+ *
+ * Without an error mapper, the error type is `Error` (no unsafe cast).
+ * With an error mapper, you control the error type precisely.
  *
  * @example
- * const divide = (x: number, y: number) => {
+ * // Error type is Error (safe default)
+ * const result = await fromPromise(fetch('/api/data'));
+ *
+ * // Custom error type via mapper
+ * const result = await fromPromise(fetch('/api'), e => e.message);
+ */
+export function fromPromise<T>(promise: Promise<T>): Promise<Result<T, Error>>;
+export function fromPromise<T, E>(promise: Promise<T>, mapError: (e: Error) => E): Promise<Result<T, E>>;
+export async function fromPromise<T, E = Error>(
+  promise: Promise<T>,
+  mapError?: (e: Error) => E,
+): Promise<Result<T, E>> {
+  try {
+    return Ok(await promise);
+  } catch (error) {
+    const normalized = normalizeError(error);
+    return Err((mapError ? mapError(normalized) : normalized) as E);
+  }
+}
+
+/**
+ * Wraps a throwing function into one that returns Result.
+ *
+ * Without an error mapper, errors are normalized to `Error`.
+ * With an error mapper, you control the error type precisely.
+ *
+ * @example
+ * const safeDivide = tryCatch((x: number, y: number) => {
  *   if (y === 0) throw new Error('Division by zero');
  *   return x / y;
- * };
- *
- * const safeDivide = tryCatch(divide);
+ * });
  * safeDivide(10, 0); // Err(Error('Division by zero'))
  * safeDivide(10, 2); // Ok(5)
+ *
+ * // With custom error type
+ * const safe = tryCatch(parse, e => e.message);
+ * safe(input); // Result<T, string>
  */
-export const tryCatch =
-  <T extends unknown[], R, E = Error>(fn: (...args: T) => R) =>
-  (...args: T): Result<R, E> => {
+export function tryCatch<T extends unknown[], R>(
+  fn: (...args: T) => R,
+): (...args: T) => Result<R, Error>;
+export function tryCatch<T extends unknown[], R, E>(
+  fn: (...args: T) => R,
+  mapError: (e: Error) => E,
+): (...args: T) => Result<R, E>;
+export function tryCatch<T extends unknown[], R, E = Error>(
+  fn: (...args: T) => R,
+  mapError?: (e: Error) => E,
+): (...args: T) => Result<R, E> {
+  return (...args: T): Result<R, E> => {
     try {
       return Ok(fn(...args));
     } catch (error) {
-      return Err((error instanceof Error ? error : new Error(String(error))) as unknown as E);
+      const normalized = normalizeError(error);
+      return Err((mapError ? mapError(normalized) : normalized) as E);
     }
   };
+}
 
 // ============================================================================
 // BIMAP / MAPBOTH
@@ -441,28 +477,43 @@ export const swap = <T, E>(result: Result<T, E>): Result<E, T> =>
   isOk(result) ? Err(result.value) : Ok(result.error);
 
 /**
- * Async version of tryCatch
+ * Wraps an async throwing function into one that returns Promise<Result>.
+ *
+ * Without an error mapper, errors are normalized to `Error`.
+ * With an error mapper, you control the error type precisely.
  *
  * @example
- * const fetchUser = async (id: string) => {
+ * const safeFetch = tryCatchAsync(async (id: string) => {
  *   const res = await fetch(`/users/${id}`);
  *   if (!res.ok) throw new Error('Not found');
  *   return res.json();
- * };
- *
- * const safeFetch = tryCatchAsync(fetchUser);
+ * });
  * await safeFetch('123'); // Result<User, Error>
+ *
+ * // With custom error type
+ * const safe = tryCatchAsync(fetchUser, e => e.message);
+ * await safe('123'); // Result<User, string>
  */
-export const tryCatchAsync =
-  <T extends unknown[], R, E = Error>(fn: (...args: T) => Promise<R>) =>
-  async (...args: T): Promise<Result<R, E>> => {
+export function tryCatchAsync<T extends unknown[], R>(
+  fn: (...args: T) => Promise<R>,
+): (...args: T) => Promise<Result<R, Error>>;
+export function tryCatchAsync<T extends unknown[], R, E>(
+  fn: (...args: T) => Promise<R>,
+  mapError: (e: Error) => E,
+): (...args: T) => Promise<Result<R, E>>;
+export function tryCatchAsync<T extends unknown[], R, E = Error>(
+  fn: (...args: T) => Promise<R>,
+  mapError?: (e: Error) => E,
+): (...args: T) => Promise<Result<R, E>> {
+  return async (...args: T): Promise<Result<R, E>> => {
     try {
-      const value = await fn(...args);
-      return Ok(value);
+      return Ok(await fn(...args));
     } catch (error) {
-      return Err((error instanceof Error ? error : new Error(String(error))) as unknown as E);
+      const normalized = normalizeError(error);
+      return Err((mapError ? mapError(normalized) : normalized) as E);
     }
   };
+}
 
 /**
  * Async map over Result
@@ -612,4 +663,63 @@ export const validateCollect =
     }
 
     return errors.length === 0 ? Ok(value) : Err(errors);
+  };
+
+// ============================================================================
+// ADDITIONAL COMBINATORS
+// ============================================================================
+
+/**
+ * Alias for flatMap — standard FP name (Fantasy Land, fp-ts).
+ */
+export const chain = flatMap;
+
+/**
+ * Alias for combineAll — standard FP name for collecting an array of Results.
+ */
+export const sequenceResult = combineAll;
+
+/**
+ * Lifts a predicate into a Result. Returns Ok if the predicate holds,
+ * otherwise Err with the value produced by `onFalse`.
+ *
+ * @example
+ * const isPositive = fromPredicate(
+ *   (n: number) => n > 0,
+ *   n => `${n} is not positive`,
+ * );
+ * isPositive(5);  // Ok(5)
+ * isPositive(-1); // Err('-1 is not positive')
+ */
+export const fromPredicate =
+  <T, E>(predicate: (value: T) => boolean, onFalse: (value: T) => E) =>
+  (value: T): Result<T, E> =>
+    predicate(value) ? Ok(value) : Err(onFalse(value));
+
+/**
+ * Maps each element through a Result-returning function and collects
+ * all Ok values. Short-circuits on the first Err (fail-fast).
+ *
+ * More efficient than `map(fn) |> combineAll` because it avoids
+ * building the intermediate Result array.
+ *
+ * @example
+ * const parseNum = (s: string): Result<number, string> => {
+ *   const n = Number(s);
+ *   return isNaN(n) ? Err(`"${s}" is not a number`) : Ok(n);
+ * };
+ *
+ * traverseResult(parseNum)(['1', '2', '3']); // Ok([1, 2, 3])
+ * traverseResult(parseNum)(['1', 'x', '3']); // Err('"x" is not a number')
+ */
+export const traverseResult =
+  <T, R, E>(fn: (value: T) => Result<R, E>) =>
+  (arr: T[]): Result<R[], E> => {
+    const values: R[] = [];
+    for (const item of arr) {
+      const result = fn(item);
+      if (isErr(result)) return result;
+      values.push(result.value);
+    }
+    return Ok(values);
   };

--- a/tests/option.test.ts
+++ b/tests/option.test.ts
@@ -10,6 +10,7 @@ import {
   toNullable, toArray,
   zipOption, sequenceOption, compactOptions,
   filterOption, getOrElse, getOr,
+  fromPredicateOption, traverseOption,
 } from '../src/option.js';
 import { Ok, Err, isOk, isErr } from '../src/result.js';
 import { optionToResult, resultToOption } from '../src/interop.js';
@@ -205,5 +206,42 @@ describe('getOr', () => {
   });
   it('returns default on None', () => {
     expect(getOr(99)(None)).toBe(99);
+  });
+});
+
+// ============================================================================
+// New combinators
+// ============================================================================
+
+describe('Option — fromPredicateOption', () => {
+  const positive = fromPredicateOption((n: number) => n > 0);
+
+  it('returns Some when predicate holds', () => {
+    expect(positive(5)).toEqual(Some(5));
+  });
+
+  it('returns None when predicate fails', () => {
+    expect(positive(-1)).toBe(None);
+  });
+
+  it('returns None for zero', () => {
+    expect(positive(0)).toBe(None);
+  });
+});
+
+describe('Option — traverseOption', () => {
+  const safeSqrt = (n: number) =>
+    n >= 0 ? Some(Math.sqrt(n)) : None;
+
+  it('maps and sequences (all Some)', () => {
+    expect(traverseOption(safeSqrt)([4, 9, 16])).toEqual(Some([2, 3, 4]));
+  });
+
+  it('short-circuits on first None', () => {
+    expect(traverseOption(safeSqrt)([4, -1, 16])).toBe(None);
+  });
+
+  it('returns Some([]) for empty array', () => {
+    expect(traverseOption(safeSqrt)([])).toEqual(Some([]));
   });
 });

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -3,7 +3,7 @@ import {
   Ok, Err,
   isOk, isErr,
   mapResult, mapErr,
-  flatMap, andThen,
+  flatMap, andThen, chain,
   match,
   unwrap, unwrapOr, unwrapOrElse,
   combineAll, combineTwo, collectErrors,
@@ -14,6 +14,7 @@ import {
   tapResult, tapError, orElse, fromNullableResult,
   bimap, mapLeft, swap,
   ap, liftA2, liftA3,
+  fromPredicate, sequenceResult, traverseResult,
   type Result,
 } from '../src/result.js';
 import { Some, None } from '../src/option.js';
@@ -437,5 +438,135 @@ describe('liftA3', () => {
       Err<number, string>('second'),
       Err<number, string>('third'),
     )).toEqual(Err('first'));
+  });
+});
+
+// ============================================================================
+// _tag discriminant
+// ============================================================================
+
+describe('Result — _tag discriminant', () => {
+  it('Ok has _tag "Ok"', () => {
+    const r = Ok(42);
+    expect(r._tag).toBe('Ok');
+  });
+
+  it('Err has _tag "Err"', () => {
+    const r = Err('fail');
+    expect(r._tag).toBe('Err');
+  });
+
+  it('isOk narrows via _tag', () => {
+    const r: Result<number, string> = Ok(1);
+    if (isOk(r)) {
+      expect(r._tag).toBe('Ok');
+      expect(r.value).toBe(1);
+    }
+  });
+
+  it('isErr narrows via _tag', () => {
+    const r: Result<number, string> = Err('x');
+    if (isErr(r)) {
+      expect(r._tag).toBe('Err');
+      expect(r.error).toBe('x');
+    }
+  });
+});
+
+// ============================================================================
+// New combinators
+// ============================================================================
+
+describe('Result — fromPredicate', () => {
+  const isPositive = fromPredicate(
+    (n: number) => n > 0,
+    (n: number) => `${n} is not positive`,
+  );
+
+  it('returns Ok when predicate passes', () => {
+    expect(isPositive(5)).toEqual(Ok(5));
+  });
+
+  it('returns Err when predicate fails', () => {
+    expect(isPositive(-1)).toEqual(Err('-1 is not positive'));
+  });
+});
+
+describe('Result — chain (alias for flatMap)', () => {
+  it('chains like flatMap', () => {
+    const double = (n: number): Result<number, string> => Ok(n * 2);
+    expect(chain(double)(Ok(5))).toEqual(Ok(10));
+    expect(chain(double)(Err('x'))).toEqual(Err('x'));
+  });
+});
+
+describe('Result — sequenceResult (alias for combineAll)', () => {
+  it('sequences like combineAll', () => {
+    expect(sequenceResult([Ok(1), Ok(2), Ok(3)])).toEqual(Ok([1, 2, 3]));
+    expect(isErr(sequenceResult([Ok(1), Err('x')]))).toBe(true);
+  });
+});
+
+describe('Result — traverseResult', () => {
+  const parseNum = (s: string): Result<number, string> => {
+    const n = Number(s);
+    return isNaN(n) ? Err(`"${s}" is not a number`) : Ok(n);
+  };
+
+  it('maps and sequences in one pass (all Ok)', () => {
+    expect(traverseResult(parseNum)(['1', '2', '3'])).toEqual(Ok([1, 2, 3]));
+  });
+
+  it('short-circuits on first Err', () => {
+    const result = traverseResult(parseNum)(['1', 'x', '3']);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) expect(result.error).toBe('"x" is not a number');
+  });
+
+  it('returns Ok([]) for empty array', () => {
+    expect(traverseResult(parseNum)([])).toEqual(Ok([]));
+  });
+});
+
+describe('Result — fromPromise with error mapper', () => {
+  it('returns Ok for resolved promise', async () => {
+    const r = await fromPromise(Promise.resolve(42));
+    expect(r).toEqual(Ok(42));
+  });
+
+  it('returns Err(Error) without mapper', async () => {
+    const r = await fromPromise(Promise.reject(new Error('fail')));
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error).toBeInstanceOf(Error);
+  });
+
+  it('returns Err(E) with mapper', async () => {
+    const r = await fromPromise(
+      Promise.reject(new Error('fail')),
+      e => e.message,
+    );
+    expect(r).toEqual(Err('fail'));
+  });
+});
+
+describe('Result — tryCatch with error mapper', () => {
+  it('returns Ok for non-throwing fn', () => {
+    const safe = tryCatch((n: number) => n * 2);
+    expect(safe(5)).toEqual(Ok(10));
+  });
+
+  it('returns Err(Error) without mapper', () => {
+    const safe = tryCatch(() => { throw new Error('boom'); });
+    const r = safe();
+    expect(isErr(r)).toBe(true);
+    if (isErr(r)) expect(r.error).toBeInstanceOf(Error);
+  });
+
+  it('returns Err(E) with mapper', () => {
+    const safe = tryCatch(
+      () => { throw new Error('boom'); },
+      e => e.message,
+    );
+    expect(safe()).toEqual(Err('boom'));
   });
 });

--- a/tests/type-inference.test.ts
+++ b/tests/type-inference.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Type-level tests — verify that TypeScript infers correctly at compile time.
+ * These tests use vitest's `expectTypeOf` to assert type inference
+ * without runtime behavior, ensuring the library's type contracts hold.
+ */
+import { describe, it, expectTypeOf } from 'vitest';
+import { pipe } from '../src/composition.js';
+import {
+  Ok, Err, isOk, isErr, fromPromise, tryCatch, tryCatchAsync,
+  fromPredicate, traverseResult,
+  type Result,
+} from '../src/result.js';
+import {
+  Some, None, fromNullable, fromPredicateOption, traverseOption,
+  type Option,
+} from '../src/option.js';
+import { compact } from '../src/array.js';
+
+// ============================================================================
+// Result: _tag discriminant
+// ============================================================================
+
+describe('Result type-level inference', () => {
+  it('Ok has _tag "Ok"', () => {
+    const r = Ok(42);
+    expectTypeOf(r).toMatchTypeOf<Result<number, Error>>();
+    if (isOk(r)) {
+      expectTypeOf(r._tag).toEqualTypeOf<'Ok'>();
+      expectTypeOf(r.value).toEqualTypeOf<number>();
+    }
+  });
+
+  it('Err has _tag "Err"', () => {
+    const r = Err('fail');
+    if (isErr(r)) {
+      expectTypeOf(r._tag).toEqualTypeOf<'Err'>();
+      expectTypeOf(r.error).toEqualTypeOf<string>();
+    }
+  });
+
+  it('Result discriminated union narrows via _tag', () => {
+    const r: Result<number, string> = Ok(1);
+    if (r._tag === 'Ok') {
+      expectTypeOf(r.value).toEqualTypeOf<number>();
+    } else {
+      expectTypeOf(r.error).toEqualTypeOf<string>();
+    }
+  });
+});
+
+// ============================================================================
+// Option: _tag discriminant consistency
+// ============================================================================
+
+describe('Option type-level inference', () => {
+  it('Some has _tag "Some"', () => {
+    const o = Some(42);
+    expectTypeOf(o).toMatchTypeOf<Option<number>>();
+  });
+
+  it('None is Option<never>', () => {
+    expectTypeOf(None).toEqualTypeOf<Option<never>>();
+  });
+
+  it('fromNullable narrows correctly', () => {
+    const o = fromNullable<string>('hello');
+    expectTypeOf(o).toEqualTypeOf<Option<string>>();
+  });
+});
+
+// ============================================================================
+// pipe: type inference across steps
+// ============================================================================
+
+describe('pipe type inference', () => {
+  it('infers through multiple steps', () => {
+    const result = pipe(
+      5,
+      (n: number) => String(n),
+      (s: string) => s.length,
+      (n: number) => n > 0,
+    );
+    expectTypeOf(result).toEqualTypeOf<boolean>();
+  });
+
+  it('single value passes through', () => {
+    const result = pipe(42);
+    expectTypeOf(result).toEqualTypeOf<number>();
+  });
+});
+
+// ============================================================================
+// fromPromise: overload inference
+// ============================================================================
+
+describe('fromPromise type inference', () => {
+  it('without mapper returns Result<T, Error>', () => {
+    const p = fromPromise(Promise.resolve(42));
+    expectTypeOf(p).toEqualTypeOf<Promise<Result<number, Error>>>();
+  });
+
+  it('with mapper returns Result<T, E>', () => {
+    const p = fromPromise(Promise.resolve(42), e => e.message);
+    expectTypeOf(p).toEqualTypeOf<Promise<Result<number, string>>>();
+  });
+});
+
+// ============================================================================
+// tryCatch / tryCatchAsync: overload inference
+// ============================================================================
+
+describe('tryCatch type inference', () => {
+  it('without mapper returns Result<R, Error>', () => {
+    const safe = tryCatch((n: number) => n * 2);
+    const r = safe(5);
+    expectTypeOf(r).toEqualTypeOf<Result<number, Error>>();
+  });
+
+  it('with mapper returns Result<R, E>', () => {
+    const safe = tryCatch((n: number) => n * 2, e => e.message);
+    const r = safe(5);
+    expectTypeOf(r).toEqualTypeOf<Result<number, string>>();
+  });
+
+  it('tryCatchAsync without mapper returns Result<R, Error>', () => {
+    const safe = tryCatchAsync(async (n: number) => n * 2);
+    const r = safe(5);
+    expectTypeOf(r).toEqualTypeOf<Promise<Result<number, Error>>>();
+  });
+
+  it('tryCatchAsync with mapper returns Result<R, E>', () => {
+    const safe = tryCatchAsync(async (n: number) => n * 2, e => e.message);
+    const r = safe(5);
+    expectTypeOf(r).toEqualTypeOf<Promise<Result<number, string>>>();
+  });
+});
+
+// ============================================================================
+// New combinators: fromPredicate, traverse
+// ============================================================================
+
+describe('combinator type inference', () => {
+  it('fromPredicate infers T and E', () => {
+    const isPositive = fromPredicate(
+      (n: number) => n > 0,
+      (n: number) => `${n} is not positive`,
+    );
+    const r = isPositive(5);
+    expectTypeOf(r).toEqualTypeOf<Result<number, string>>();
+  });
+
+  it('traverseResult infers array element types', () => {
+    const fn = (s: string): Result<number, string> => Ok(Number(s));
+    const r = traverseResult(fn)(['1', '2']);
+    expectTypeOf(r).toEqualTypeOf<Result<number[], string>>();
+  });
+
+  it('traverseOption infers array element types', () => {
+    const fn = (n: number): Option<string> => Some(String(n));
+    const r = traverseOption(fn)([1, 2]);
+    expectTypeOf(r).toEqualTypeOf<Option<string[]>>();
+  });
+
+  it('fromPredicateOption infers T', () => {
+    const positive = fromPredicateOption((n: number) => n > 0);
+    const r = positive(5);
+    expectTypeOf(r).toEqualTypeOf<Option<number>>();
+  });
+});
+
+// ============================================================================
+// compact: type narrowing
+// ============================================================================
+
+describe('compact type narrowing', () => {
+  it('removes falsy types from union', () => {
+    const arr: Array<number | null | undefined | false | 0 | ''> = [1, null, 2, undefined, 0, false, '', 3];
+    const result = compact(arr);
+    expectTypeOf(result).toEqualTypeOf<number[]>();
+  });
+});


### PR DESCRIPTION
## Summary

- **Result `_tag` discriminant** — ADT consistency with Option (`_tag: 'Ok' | 'Err'`), branded types, `readonly` fields
- **Type safety** — eliminated all `as unknown as E` casts via error mapper overloads in `fromPromise`, `tryCatch`, `tryCatchAsync`; `compact` uses type predicate instead of `as T[]`
- **New combinators** — `fromPredicate`, `traverseResult`, `traverseOption`, `fromPredicateOption`, `chain` (alias), `sequenceResult` (alias)
- **Performance** — `pipe`/`compose`/`flow` use for-loops instead of `reduce`/`reduceRight`; `pipeAsync` hoists `runPipeline` to module scope
- **API cleanup** — deprecated `combineTwo` (use `liftA2`), deprecated `resultToOption` (use `toOption`)
- **Branding** — all `fp-core`/`roxdavirox` references replaced with `alchemy`/`tecnomancy`
- **CI** — Node 18 added to test matrix (matching `engines: >=18`)
- **Type-level tests** — 19 compile-time inference tests via `expectTypeOf`

### Breaking changes (pre-1.0, semver minor)
- `Result` type now requires `_tag` field — manual `{ ok: true, value: x }` construction without `_tag` will fail type-checking
- `fromPromise`/`tryCatch`/`tryCatchAsync` without error mapper now return `Result<T, Error>` (not `Result<T, E>`)

### Stats
- 494 tests (42 new), 9 test files
- 0 type errors, 0 lint warnings, 0 audit vulnerabilities

## Test plan
- [x] `npm run type-check` — zero errors
- [x] `npm test` — 494/494 passed
- [x] `npm run lint` — zero warnings  
- [x] `npm run build` — clean dist output
- [x] `npm audit` — zero vulnerabilities
- [x] Type inference tests validate compile-time contracts